### PR TITLE
Provide AD Auth for HTTP clients

### DIFF
--- a/http-server/pom.xml
+++ b/http-server/pom.xml
@@ -92,6 +92,11 @@
             <artifactId>jetty-jmx</artifactId>
             <version>8.0.3.v20111011</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-plus</artifactId>
+            <version>8.0.3.v20111011</version>
+        </dependency>
 
         <dependency>
             <groupId>joda-time</groupId>

--- a/http-server/src/main/java/com/proofpoint/http/server/HttpServerConfig.java
+++ b/http-server/src/main/java/com/proofpoint/http/server/HttpServerConfig.java
@@ -41,6 +41,9 @@ public class HttpServerConfig
 
     private String userAuthFile;
 
+    private String jaasLoginModuleName;
+    private String jaasConfigFile;
+
     private boolean adminEnabled = true;
     private int adminPort = 0;
 
@@ -209,6 +212,30 @@ public class HttpServerConfig
     public HttpServerConfig setUserAuthFile(String userAuthFile)
     {
         this.userAuthFile = userAuthFile;
+        return this;
+    }
+
+    public String getJaasLoginModuleName()
+    {
+        return jaasLoginModuleName;
+    }
+
+    @Config("http-server.auth.jaas.module")
+    public HttpServerConfig setJaasLoginModuleName(String jaasLoginModuleName)
+    {
+        this.jaasLoginModuleName = jaasLoginModuleName;
+        return this;
+    }
+
+    public String getJaasConfigFile()
+    {
+        return jaasConfigFile;
+    }
+
+    @Config("http-server.auth.jaas.config-file")
+    public HttpServerConfig setJaasConfigFile(String jaasConfigFile)
+    {
+        this.jaasConfigFile = jaasConfigFile;
         return this;
     }
 

--- a/http-server/src/main/java/com/proofpoint/http/server/JaasLoginServiceProvider.java
+++ b/http-server/src/main/java/com/proofpoint/http/server/JaasLoginServiceProvider.java
@@ -1,0 +1,40 @@
+package com.proofpoint.http.server;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import org.eclipse.jetty.plus.jaas.JAASLoginService;
+import org.eclipse.jetty.security.DefaultIdentityService;
+
+public class JaasLoginServiceProvider
+        implements Provider<JAASLoginService>
+{
+    private final String loginModuleName;
+
+    @Inject
+    public JaasLoginServiceProvider(HttpServerConfig config)
+    {
+        if (config.getJaasConfigFile() != null) {
+            this.loginModuleName = config.getJaasLoginModuleName();
+            System.setProperty("java.security.auth.login.config", config.getJaasConfigFile());
+        }
+        else {
+            this.loginModuleName = null;
+        }
+    }
+
+    @Override
+    public JAASLoginService get()
+    {
+        if (this.loginModuleName == null) {
+            return null;
+        }
+
+        JAASLoginService service = new JAASLoginService();
+
+        service.setName(HttpServerModule.REALM_NAME);
+        service.setLoginModuleName(this.loginModuleName);
+        service.setIdentityService(new DefaultIdentityService());
+
+        return service;
+    }
+}

--- a/http-server/src/test/java/com/proofpoint/http/server/AlwaysSuccessfulLoginModule.java
+++ b/http-server/src/test/java/com/proofpoint/http/server/AlwaysSuccessfulLoginModule.java
@@ -1,0 +1,113 @@
+package com.proofpoint.http.server;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+import java.security.Principal;
+import java.util.Map;
+
+public class AlwaysSuccessfulLoginModule
+    implements LoginModule
+{
+    private Subject subject;
+    private CallbackHandler callbackHandler;
+    private Principal user;
+
+    public static class DummyPrincipal
+        implements Principal
+    {
+        private final String name;
+
+        public DummyPrincipal(String name)
+        {
+            this.name = name;
+        }
+
+        @Override
+        public String getName()
+        {
+            return name;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            DummyPrincipal that = (DummyPrincipal) o;
+
+            if (name != null ? !name.equals(that.name) : that.name != null) {
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return name != null ? name.hashCode() : 0;
+        }
+    }
+
+    @Override
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> stringMap, Map<String, ?> stringMap1)
+    {
+        this.subject = subject;
+        this.callbackHandler = callbackHandler;
+    }
+
+    @Override
+    public boolean login()
+            throws LoginException
+    {
+        NameCallback nameCallback = new NameCallback("user name: ");
+        PasswordCallback passwordCallback = new PasswordCallback("password: ", false);
+
+        Callback[] callbacks = new Callback[2];
+        callbacks[0] = nameCallback;
+        callbacks[1] = passwordCallback;
+
+        try {
+            callbackHandler.handle(callbacks);
+        }
+        catch (Exception e) {
+            throw new LoginException(String.format("Callback handling bombed out [%s]", e.getMessage()));
+        }
+
+        user = new DummyPrincipal(nameCallback.getName());
+        return true;
+    }
+
+    @Override
+    public boolean commit()
+            throws LoginException
+    {
+        subject.getPrincipals().add(user);
+        return true;
+    }
+
+    @Override
+    public boolean abort()
+            throws LoginException
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean logout()
+            throws LoginException
+    {
+        subject.getPrincipals().remove(user);
+        return true;
+    }
+}

--- a/http-server/src/test/java/com/proofpoint/http/server/TestHttpServerConfig.java
+++ b/http-server/src/test/java/com/proofpoint/http/server/TestHttpServerConfig.java
@@ -44,6 +44,8 @@ public class TestHttpServerConfig
                 .setUserAuthFile(null)
                 .setAdminEnabled(true)
                 .setAdminPort(0)
+                .setJaasConfigFile(null)
+                .setJaasLoginModuleName(null)
         );
     }
 
@@ -66,6 +68,8 @@ public class TestHttpServerConfig
                 .put("http-server.auth.users-file", "/auth")
                 .put("http-server.admin.enabled", "false")
                 .put("http-server.admin.port", "3")
+                .put("http-server.auth.jaas.module", "ldap")
+                .put("http-server.auth.jaas.config-file", "/jaas/config")
                 .build();
 
         HttpServerConfig expected = new HttpServerConfig()
@@ -83,7 +87,9 @@ public class TestHttpServerConfig
                 .setNetworkMaxIdleTime(new Duration(20, TimeUnit.MINUTES))
                 .setUserAuthFile("/auth")
                 .setAdminEnabled(false)
-                .setAdminPort(3);
+                .setAdminPort(3)
+                .setJaasLoginModuleName("ldap")
+                .setJaasConfigFile("/jaas/config");
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
I followed the existing model for hash login service; added similar implementation for JAAS, which will allow configurable AD support.
