### PR TITLE
Return 400 (BAD_REQUEST) when an EOFException occurs...

### DIFF
--- a/jaxrs/src/main/java/com/proofpoint/jaxrs/JsonMapper.java
+++ b/jaxrs/src/main/java/com/proofpoint/jaxrs/JsonMapper.java
@@ -118,13 +118,8 @@ class JsonMapper implements MessageBodyReader<Object>, MessageBodyWriter<Object>
             object = objectMapper.readValue(jsonParser, TypeFactory.type(genericType));
         }
         catch (Exception e) {
-            // EOFException occurs when the input is blank.  We treat that as
-            // null input.
-            if (e instanceof EOFException) {
-                return null;
-            }
             // we want to return a 400 for bad JSON but not for a real IO exception
-            else if (e instanceof IOException && !(e instanceof JsonProcessingException)) {
+            if (e instanceof IOException && !(e instanceof JsonProcessingException) && !(e instanceof EOFException)) {
                 throw (IOException) e;
             }
 

--- a/jaxrs/src/test/java/com/proofpoint/jaxrs/TestJsonMapper.java
+++ b/jaxrs/src/test/java/com/proofpoint/jaxrs/TestJsonMapper.java
@@ -1,0 +1,138 @@
+package com.proofpoint.jaxrs;
+
+import org.codehaus.jackson.JsonProcessingException;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response.Status;
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.ZipException;
+
+public class TestJsonMapper
+{
+    @Test
+    public void testEOFExceptionTeturnsWebAppException()
+            throws IOException
+    {
+        try {
+            JsonMapper jsonMapper = new JsonMapper(new ObjectMapper(), null);
+            InputStream is = new ByteArrayInputStream("foo".getBytes());
+            jsonMapper.readFrom(Object.class, Object.class, null, null, null, new InputStream()
+            {
+                @Override
+                public int read()
+                        throws IOException
+                {
+                    throw new EOFException("forced EOF Exception");
+                }
+
+                @Override
+                public int read(byte[] b)
+                        throws IOException
+                {
+                    throw new EOFException("forced EOF Exception");
+                }
+
+                @Override
+                public int read(byte[] b, int off, int len)
+                        throws IOException
+                {
+                    throw new EOFException("forced EOF Exception");
+                }
+            });
+            Assert.fail("Should have thrown a WebApplicationException");
+        }
+        catch (WebApplicationException e) {
+            Assert.assertEquals(e.getResponse().getStatus(), Status.BAD_REQUEST.getStatusCode());
+            Assert.assertTrue(((String) e.getResponse().getEntity()).startsWith("Invalid json for Java type"));
+        }
+    }
+
+    @Test
+    public void testJsonProcessingExceptionThrowsWebAppException()
+            throws IOException
+    {
+        try {
+            JsonMapper jsonMapper = new JsonMapper(new ObjectMapper(), null);
+            InputStream is = new ByteArrayInputStream("foo".getBytes());
+            jsonMapper.readFrom(Object.class, Object.class, null, null, null, new InputStream()
+            {
+                @Override
+                public int read()
+                        throws IOException
+                {
+                    throw new TestingJsonProcessingException("forced JsonProcessingException");
+                }
+
+                @Override
+                public int read(byte[] b)
+                        throws IOException
+                {
+                    throw new TestingJsonProcessingException("forced JsonProcessingException");
+                }
+
+                @Override
+                public int read(byte[] b, int off, int len)
+                        throws IOException
+                {
+                    throw new TestingJsonProcessingException("forced JsonProcessingException");
+                }
+            });
+            Assert.fail("Should have thrown a WebApplicationException");
+        }
+        catch (WebApplicationException e) {
+            Assert.assertEquals(e.getResponse().getStatus(), Status.BAD_REQUEST.getStatusCode());
+            Assert.assertTrue(((String) e.getResponse().getEntity()).startsWith("Invalid json for Java type"));
+        }
+    }
+
+    @Test(expectedExceptions = IOException.class)
+    public void testOtherIOExceptionThrowsIOException()
+            throws IOException
+    {
+        try {
+            JsonMapper jsonMapper = new JsonMapper(new ObjectMapper(), null);
+            InputStream is = new ByteArrayInputStream("foo".getBytes());
+            jsonMapper.readFrom(Object.class, Object.class, null, null, null, new InputStream()
+            {
+                @Override
+                public int read()
+                        throws IOException
+                {
+                    throw new ZipException("forced ZipException");
+                }
+
+                @Override
+                public int read(byte[] b)
+                        throws IOException
+                {
+                    throw new ZipException("forced ZipException");
+                }
+
+                @Override
+                public int read(byte[] b, int off, int len)
+                        throws IOException
+                {
+                    throw new ZipException("forced ZipException");
+                }
+            });
+            Assert.fail("Should have thrown an IOException");
+        }
+        catch (WebApplicationException e) {
+            Assert.fail("Should not have received a WebApplicationException", e);
+        }
+    }
+
+    private static class TestingJsonProcessingException extends JsonProcessingException
+    {
+        public TestingJsonProcessingException(String message)
+        {
+            super(message);
+        }
+    }
+}


### PR DESCRIPTION
instead of an IOException, which causes a platform based server to
return a 500 error.

The EOFException occurs when the input is blank (e.g. a blank string). It seems reasonable that when the server encounters a blank string, this should be treated as a "bad JSON" (400, BAD_REQUEST), instead of crashing the request. 

(Note, pull request title and initial comments changed to reflect change from returning null to returning a 404. 
