### PR TITLE
update to jetty 8.1.1 to fix socket leak

### DIFF
--- a/http-server/pom.xml
+++ b/http-server/pom.xml
@@ -65,32 +65,32 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>8.0.3.v20111011</version>
+            <version>8.1.1.v20120215</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
-            <version>8.0.3.v20111011</version>
+            <version>8.1.1.v20120215</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>8.0.3.v20111011</version>
+            <version>8.1.1.v20120215</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlets</artifactId>
-            <version>8.0.3.v20111011</version>
+            <version>8.1.1.v20120215</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-security</artifactId>
-            <version>8.0.3.v20111011</version>
+            <version>8.1.1.v20120215</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-jmx</artifactId>
-            <version>8.0.3.v20111011</version>
+            <version>8.1.1.v20120215</version>
         </dependency>
 
         <dependency>

--- a/http-server/src/main/java/com/proofpoint/http/server/HttpServer.java
+++ b/http-server/src/main/java/com/proofpoint/http/server/HttpServer.java
@@ -19,7 +19,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.proofpoint.node.NodeInfo;
 import com.proofpoint.tracetoken.TraceTokenManager;
-import org.eclipse.jetty.http.security.Constraint;
 import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
@@ -38,6 +37,7 @@ import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.servlets.GzipFilter;
+import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
 import javax.annotation.PostConstruct;
@@ -146,6 +146,7 @@ public class HttpServer
             adminThreadPool.setMaxIdleTimeMs((int) config.getThreadMaxIdleTime().convertTo(TimeUnit.MILLISECONDS));
             adminConnector.setThreadPool(adminThreadPool);
 
+            server.addBean(adminThreadPool); // workaround until jetty bug 373272 is fixed
             server.addConnector(adminConnector);
         }
 


### PR DESCRIPTION
jetty 8.0.3 has an issue where tcp connections will leak
in CLOSE_WAIT state if clients hang up prematurely
