### PR TITLE
EquivalenceTester improvements

### DIFF
--- a/testing/src/main/java/com/proofpoint/testing/EquivalenceTester.java
+++ b/testing/src/main/java/com/proofpoint/testing/EquivalenceTester.java
@@ -117,9 +117,13 @@ public final class EquivalenceTester
                         }
                     }
 
-                    // nothing can be equal to object of another class
-                    if (element.equals(new OtherClass())) {
-                        errors.add(new ElementCheckFailure(EQUAL_TO_OTHER_CLASS, classNumber, elementNumber));
+                    // nothing can be equal to object of an unrelated class
+                    try {
+                        if (element.equals(new OtherClass())) {
+                            errors.add(new ElementCheckFailure(EQUAL_TO_UNRELATED_CLASS, classNumber, elementNumber));
+                        }
+                    } catch (ClassCastException e) {
+                        errors.add(new ElementCheckFailure(EQUAL_TO_UNRELATED_CLASS_CLASS_CAST_EXCEPTION, classNumber, elementNumber));
                     }
 
                     ++elementNumber;
@@ -380,7 +384,8 @@ public final class EquivalenceTester
         EQUAL_TO_NULL("Element (%d, %d) returns true when compared to null via equals()"),
         EQUAL_NULL_EXCEPTION("Element (%d, %d) throws NullPointerException when when compared to null via equals()"),
         COMPARE_EQUAL_TO_NULL("Element (%d, %d) implements Comparable but does not throw NullPointerException when compared to null"),
-        EQUAL_TO_OTHER_CLASS("Element (%d, %d) returns true when compared to a different class via equals()"),
+        EQUAL_TO_UNRELATED_CLASS("Element (%d, %d) returns true when compared to an unrelated class via equals()"),
+        EQUAL_TO_UNRELATED_CLASS_CLASS_CAST_EXCEPTION("Element (%d, %d) throws a ClassCastException when compared to an unrelated class via equals()"),
         NOT_REFLEXIVE("Element (%d, %d) is not equal to itself when compared via equals()"),
         COMPARE_NOT_REFLEXIVE("Element (%d, %d) implements Comparable but compare does not return 0 when compared to itself"),
         NOT_EQUAL("Element (%d, %d) is not equal to element (%d, %d) when compared via equals()"),

--- a/testing/src/test/java/com/proofpoint/testing/TestEquivalenceTester.java
+++ b/testing/src/test/java/com/proofpoint/testing/TestEquivalenceTester.java
@@ -39,7 +39,8 @@ import static com.proofpoint.testing.EquivalenceTester.EquivalenceFailureType.CO
 import static com.proofpoint.testing.EquivalenceTester.EquivalenceFailureType.EQUAL;
 import static com.proofpoint.testing.EquivalenceTester.EquivalenceFailureType.EQUAL_NULL_EXCEPTION;
 import static com.proofpoint.testing.EquivalenceTester.EquivalenceFailureType.EQUAL_TO_NULL;
-import static com.proofpoint.testing.EquivalenceTester.EquivalenceFailureType.EQUAL_TO_OTHER_CLASS;
+import static com.proofpoint.testing.EquivalenceTester.EquivalenceFailureType.EQUAL_TO_UNRELATED_CLASS;
+import static com.proofpoint.testing.EquivalenceTester.EquivalenceFailureType.EQUAL_TO_UNRELATED_CLASS_CLASS_CAST_EXCEPTION;
 import static com.proofpoint.testing.EquivalenceTester.EquivalenceFailureType.HASH_CODE_NOT_SAME;
 import static com.proofpoint.testing.EquivalenceTester.EquivalenceFailureType.NOT_EQUAL;
 import static com.proofpoint.testing.EquivalenceTester.EquivalenceFailureType.NOT_GREATER_THAN;
@@ -175,25 +176,48 @@ public class TestEquivalenceTester
     }
 
     @Test
-    public void equalsOtherClass()
+    public void equalsUnrelatedClass()
     {
         try {
             equivalenceTester()
-                    .addEquivalentGroup(new EqualsOtherClass())
+                    .addEquivalentGroup(new EqualsUnrelatedClass())
                     .check();
             fail("Expected EquivalenceAssertionError");
         }
         catch (EquivalenceAssertionError e) {
-            assertExpectedFailures(e, new ElementCheckFailure(EQUAL_TO_OTHER_CLASS, 0, 0));
+            assertExpectedFailures(e, new ElementCheckFailure(EQUAL_TO_UNRELATED_CLASS, 0, 0));
         }
     }
 
-    static class EqualsOtherClass
+    static class EqualsUnrelatedClass
     {
         @SuppressWarnings({"EqualsWhichDoesntCheckParameterClass"})
         public boolean equals(Object that)
         {
             return that != null;
+        }
+    }
+
+    @Test
+    public void equalsUnrelatedClassThrowsException()
+    {
+        try {
+            equivalenceTester()
+                    .addEquivalentGroup(new EqualsOtherClassThrowsException())
+                    .check();
+            fail("Expected EquivalenceAssertionError");
+        }
+        catch (EquivalenceAssertionError e) {
+            assertExpectedFailures(e, new ElementCheckFailure(EQUAL_TO_UNRELATED_CLASS_CLASS_CAST_EXCEPTION, 0, 0));
+        }
+    }
+
+    static class EqualsOtherClassThrowsException
+    {
+        @SuppressWarnings({"EqualsWhichDoesntCheckParameterClass"})
+        public boolean equals(Object that)
+        {
+            return that != null && ((EqualsOtherClassThrowsException) that).hashCode() == this.hashCode();
         }
     }
 


### PR DESCRIPTION
Make EquivalenceTester check the behavior of equals() against an object of a different class.
Make EquivalenceTester fail test when .equals(null) throws NullPointerException
