### PR TITLE
Allow ConfigAssertions.assertDeprecatedEquivalence to handle zero deprecated options

### DIFF
--- a/configuration/src/main/java/com/proofpoint/configuration/testing/ConfigAssertions.java
+++ b/configuration/src/main/java/com/proofpoint/configuration/testing/ConfigAssertions.java
@@ -131,12 +131,11 @@ public final class ConfigAssertions
         assertAttributesEqual(metadata, actual, expected);
     }
 
-    public static <T> void assertDeprecatedEquivalence(Class<T> configClass, Map<String, String> currentProperties, Map<String, String> oldProperties, Map<String, String>... evenOlderPropertiesList)
+    public static <T> void assertDeprecatedEquivalence(Class<T> configClass, Map<String, String> currentProperties, Map<String, String>... oldPropertiesList)
     {
         Assert.assertNotNull(configClass, "configClass");
         Assert.assertNotNull(currentProperties, "currentProperties");
-        Assert.assertNotNull(oldProperties, "oldProperties");
-        Assert.assertNotNull(evenOlderPropertiesList, "evenOlderPropertiesList");
+        Assert.assertNotNull(oldPropertiesList, "oldPropertiesList");
 
         ConfigurationMetadata<T> metadata = ConfigurationMetadata.getValidConfigurationMetadata(configClass);
 
@@ -144,8 +143,7 @@ public final class ConfigAssertions
         assertPropertiesSupported(metadata, currentProperties.keySet(), false);
 
         // verify all old properties are supported (deprecation allowed)
-        assertPropertiesSupported(metadata, oldProperties.keySet(), true);
-        for (Map<String, String> evenOlderProperties : evenOlderPropertiesList) {
+        for (Map<String, String> evenOlderProperties : oldPropertiesList) {
             assertPropertiesSupported(metadata, evenOlderProperties.keySet(), true);
         }
 
@@ -157,8 +155,7 @@ public final class ConfigAssertions
             }
         }
         Set<String> suppliedDeprecatedProperties = new TreeSet<String>();
-        suppliedDeprecatedProperties.addAll(oldProperties.keySet());
-        for (Map<String, String> evenOlderProperties : evenOlderPropertiesList) {
+        for (Map<String, String> evenOlderProperties : oldPropertiesList) {
             suppliedDeprecatedProperties.addAll(evenOlderProperties.keySet());
         }
         if (!suppliedDeprecatedProperties.containsAll(knownDeprecatedProperties)) {
@@ -169,9 +166,7 @@ public final class ConfigAssertions
 
         // verify property sets create equivalent configurations
         T currentConfiguration = newInstance(configClass, currentProperties);
-        T oldConfiguration = newInstance(configClass, oldProperties);
-        assertAttributesEqual(metadata, currentConfiguration, oldConfiguration);
-        for (Map<String, String> evenOlderProperties : evenOlderPropertiesList) {
+        for (Map<String, String> evenOlderProperties : oldPropertiesList) {
             T evenOlderConfiguration = newInstance(configClass, evenOlderProperties);
             assertAttributesEqual(metadata, currentConfiguration, evenOlderConfiguration);
         }

--- a/configuration/src/test/java/com/proofpoint/configuration/testing/TestConfigAssertions.java
+++ b/configuration/src/test/java/com/proofpoint/configuration/testing/TestConfigAssertions.java
@@ -303,25 +303,36 @@ public class TestConfigAssertions
     }
 
     @Test
-    public void testDeprecatedProperties()
+    public void testNoDeprecatedProperties()
     {
         Map<String, String> currentProperties = new ImmutableMap.Builder<String, String>()
                 .put("email", "alice@example.com")
                 .put("home-page", "http://example.com")
                 .build();
 
-        Map<String, String> oldProperties = new ImmutableMap.Builder<String, String>()
-                .put("exchange-id", "alice@example.com")
-                .put("home-page", "http://example.com")
-                .build();
-
-        Map<String, String> olderProperties = new ImmutableMap.Builder<String, String>()
-                .put("notes-id", "alice@example.com")
-                .put("home-page-url", "http://example.com")
-                .build();
-
-        ConfigAssertions.assertDeprecatedEquivalence(PersonConfig.class, currentProperties, oldProperties, olderProperties);
+        ConfigAssertions.assertDeprecatedEquivalence(NoDeprecatedConfig.class, currentProperties);
     }
+
+    @Test
+        public void testDeprecatedProperties()
+        {
+            Map<String, String> currentProperties = new ImmutableMap.Builder<String, String>()
+                    .put("email", "alice@example.com")
+                    .put("home-page", "http://example.com")
+                    .build();
+
+            Map<String, String> oldProperties = new ImmutableMap.Builder<String, String>()
+                    .put("exchange-id", "alice@example.com")
+                    .put("home-page", "http://example.com")
+                    .build();
+
+            Map<String, String> olderProperties = new ImmutableMap.Builder<String, String>()
+                    .put("notes-id", "alice@example.com")
+                    .put("home-page-url", "http://example.com")
+                    .build();
+
+            ConfigAssertions.assertDeprecatedEquivalence(PersonConfig.class, currentProperties, oldProperties, olderProperties);
+        }
 
     @Test
     public void testDeprecatedPropertiesFailUnsupportedProperties()
@@ -595,6 +606,62 @@ public class TestConfigAssertions
             catch (URISyntaxException e) {
                 throw new IllegalArgumentException(e);
             }
+        }
+    }
+
+    public static class NoDeprecatedConfig
+    {
+        private String name = "Dain";
+        private String email = "dain@proofpoint.com";
+        private String phone;
+        private URI homePage = URI.create("http://iq80.com");
+
+        public String getName()
+        {
+            return name;
+        }
+
+        @Config("name")
+        public NoDeprecatedConfig setName(String name)
+        {
+            this.name = name;
+            return this;
+        }
+
+        public String getEmail()
+        {
+            return email;
+        }
+
+        @Config("email")
+        public NoDeprecatedConfig setEmail(String email)
+        {
+            this.email = email;
+            return this;
+        }
+
+        public String getPhone()
+        {
+            return phone;
+        }
+
+        @Config("phone")
+        public NoDeprecatedConfig setPhone(String phone)
+        {
+            this.phone = phone;
+            return this;
+        }
+
+        public URI getHomePage()
+        {
+            return homePage;
+        }
+
+        @Config("home-page")
+        public NoDeprecatedConfig setHomePage(URI homePage)
+        {
+            this.homePage = homePage;
+            return this;
         }
     }
 }


### PR DESCRIPTION
This is the rare case of improvement by code deletion.

Inserting an assertDeprecatedEquivalence test when there are no deprecated options causes a test failure when a deprecated option is added yet the test is not updated.
