### PR TITLE
return the actual exception instead of the wrapper

### DIFF
--- a/http-client/src/main/java/com/proofpoint/http/client/ApacheHttpClient.java
+++ b/http-client/src/main/java/com/proofpoint/http/client/ApacheHttpClient.java
@@ -146,7 +146,7 @@ public class ApacheHttpClient implements com.proofpoint.http.client.HttpClient
         catch (Exception e) {
             if (e instanceof ExceptionFromResponseHandler) {
                 try {
-                    throw (E) e;
+                    throw (E) e.getCause();
                 }
                 catch (ClassCastException classCastException) {
                     // this should never happen but generics suck so be safe

--- a/http-client/src/test/java/com/proofpoint/http/client/ApacheHttpClientTest.java
+++ b/http-client/src/test/java/com/proofpoint/http/client/ApacheHttpClientTest.java
@@ -196,6 +196,19 @@ public class ApacheHttpClientTest
         Assert.assertEquals(statusCode, 543);
     }
 
+    @Test(expectedExceptions = UnexpectedResponseException.class)
+    public void testThrowsUnexpectedResponseException()
+            throws Exception
+    {
+        servlet.responseStatusCode = 543;
+        Request request = prepareGet()
+                .setUri(baseURI)
+                .build();
+
+        httpClient.execute(request, new UnexpectedResponseStatusCodeHandler(200));
+    }
+
+
     @Test
     public void testResponseStatusMessage()
             throws Exception
@@ -388,6 +401,34 @@ public class ApacheHttpClientTest
             return response.getStatusCode();
         }
     }
+
+    static class UnexpectedResponseStatusCodeHandler implements ResponseHandler<Integer, RuntimeException>
+    {
+        private int expectedStatusCode;
+
+        UnexpectedResponseStatusCodeHandler(int expectedStatusCode)
+        {
+            this.expectedStatusCode = expectedStatusCode;
+        }
+
+        @Override
+        public RuntimeException handleException(Request request, Exception exception)
+        {
+            return null;
+        }
+
+        @Override
+        public Integer handle(Request request, Response response)
+                throws RuntimeException
+        {
+            if (response.getStatusCode() != expectedStatusCode)
+            {
+                throw new UnexpectedResponseException(request, response);
+            }
+            return response.getStatusCode();
+        }
+    }
+
 
     private static class ResponseHeadersHandler
             implements ResponseHandler<ListMultimap<String, String>, Exception>


### PR DESCRIPTION
Please look at issue 125 on platform. This is urgent since we are all depending on this exception working for using this HttpClient
