### PR TITLE
Back out prohibition on generators for non-PUT/POST requests.

### DIFF
--- a/http-client/src/main/java/com/proofpoint/http/client/Request.java
+++ b/http-client/src/main/java/com/proofpoint/http/client/Request.java
@@ -40,7 +40,6 @@ public class Request
     {
         Preconditions.checkNotNull(uri, "uri is null");
         Preconditions.checkNotNull(method, "method is null");
-        validateBodyNotSetForNonEntityMethods(method, bodyGenerator);
 
         this.uri = validateUri(uri);
         this.method = method;
@@ -174,15 +173,8 @@ public class Request
         }
 
         public Request build() {
-            validateBodyNotSetForNonEntityMethods(method, bodyGenerator);
             return new Request(uri, method, headers, bodyGenerator);
         }
-    }
-
-    private static boolean validateBodyNotSetForNonEntityMethods(String method, BodyGenerator bodyGenerator)
-    {
-        Preconditions.checkState(bodyGenerator != null ? (method.equalsIgnoreCase("PUT") || method.equalsIgnoreCase("POST")) : true, "Cannot set body generator for non entity methods");
-        return true;
     }
 
     private static URI validateUri(URI uri)

--- a/http-client/src/test/java/com/proofpoint/http/client/TestRequest.java
+++ b/http-client/src/test/java/com/proofpoint/http/client/TestRequest.java
@@ -31,19 +31,29 @@ public class TestRequest
 
         EquivalenceTester.<Request>equivalenceTester()
                 .addEquivalentGroup(
+                        new Request(createUri1(), "GET", createHeaders1(), null),
+                        new Request(createUri1(), "GET", createHeaders1(), null))
+                .addEquivalentGroup(
+                        new Request(createUri1(), "GET", createHeaders1(), bodyGenerator),
+                        new Request(createUri1(), "GET", createHeaders1(), bodyGenerator))
+                .addEquivalentGroup(
+                        new Request(createUri1(), "GET", createHeaders2(), bodyGenerator))
+                .addEquivalentGroup(
+                        new Request(createUri2(), "GET", createHeaders1(), bodyGenerator))
+                .addEquivalentGroup(
                         new Request(createUri1(), "PUT", createHeaders1(), null),
                         new Request(createUri1(), "PUT", createHeaders1(), null))
                 .addEquivalentGroup(
                         new Request(createUri2(), "PUT", createHeaders1(), null))
                 .addEquivalentGroup(
-                        new Request(createUri1(), "GET", createHeaders1(), null),
-                        new Request(createUri1(), "GET", createHeaders1(), null))
-                .addEquivalentGroup(
                         new Request(createUri1(), "PUT", createHeaders2(), null))
                 .addEquivalentGroup(
-                        new Request(createUri1(), "PUT", createHeaders1(), createBodyGenerator()))
-                .addEquivalentGroup(
+                        new Request(createUri1(), "PUT", createHeaders1(), bodyGenerator),
                         new Request(createUri1(), "PUT", createHeaders1(), bodyGenerator))
+                .addEquivalentGroup(
+                        new Request(createUri1(), "GET", createHeaders1(), createBodyGenerator()))
+                .addEquivalentGroup(
+                        new Request(createUri1(), "PUT", createHeaders1(), createBodyGenerator()))
                 .check();
     }
 
@@ -51,18 +61,7 @@ public class TestRequest
     public void testCannotMakeRequestToIllegalPort()
             throws Exception
     {
-        new Request(URI.create("http://example.com:0/"), "PUT", createHeaders1(), createBodyGenerator());
-    }
-
-    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "Cannot set body generator for non entity methods")
-    public void testRequestThrowsOnUsingBodyGeneratorForGetRequest()
-    {
         new Request(URI.create("http://example.com:0/"), "GET", createHeaders1(), createBodyGenerator());
-    }
-
-    public void testSuccessfulGetRequestCreation()
-    {
-        new Request(URI.create("http://example.com:0/"), "GET", createHeaders1(), null);
     }
 
     private URI createUri1()

--- a/http-client/src/test/java/com/proofpoint/http/client/TestRequestBuilder.java
+++ b/http-client/src/test/java/com/proofpoint/http/client/TestRequestBuilder.java
@@ -22,7 +22,6 @@ import java.net.URI;
 
 import static com.proofpoint.http.client.Request.Builder.fromRequest;
 import static com.proofpoint.http.client.Request.Builder.prepareGet;
-import static com.proofpoint.http.client.Request.Builder.preparePut;
 import static com.proofpoint.http.client.StaticBodyGenerator.createStaticBodyGenerator;
 import static org.testng.Assert.assertEquals;
 
@@ -33,8 +32,8 @@ public class TestRequestBuilder
     @Test
     public void testRequestBuilder()
     {
-        Request request = createPutRequest();
-        assertEquals(request.getMethod(), "PUT");
+        Request request = createRequest();
+        assertEquals(request.getMethod(), "GET");
         assertEquals(request.getBodyGenerator(), NULL_BODY_GENERATOR);
         assertEquals(request.getUri(), URI.create("http://example.com"));
         assertEquals(request.getHeaders(), ImmutableListMultimap.of(
@@ -51,28 +50,17 @@ public class TestRequestBuilder
     @Test
     public void testBuilderFromRequest()
     {
-        Request request = createPutRequest();
+        Request request = createRequest();
         assertEquals(fromRequest(request).build(), request);
     }
 
-    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "Cannot set body generator for non entity methods")
-    public void testRequestBuilderThrowsOnUsingBodyGeneratorForGetRequest()
+    private Request createRequest()
     {
-        prepareGet()
-         .setUri(URI.create("http://example.com"))
-         .addHeader("newheader", "withvalue")
-         .addHeader("anotherheader", "anothervalue")
-         .setBodyGenerator(NULL_BODY_GENERATOR)
-         .build();
-    }
-
-    private Request createPutRequest()
-    {
-        return preparePut()
-                .setUri(URI.create("http://example.com"))
-                .addHeader("newheader", "withvalue")
-                .addHeader("anotherheader", "anothervalue")
-                .setBodyGenerator(NULL_BODY_GENERATOR)
-                .build();
+        return prepareGet()
+                    .setUri(URI.create("http://example.com"))
+                    .addHeader("newheader", "withvalue")
+                    .addHeader("anotherheader", "anothervalue")
+                    .setBodyGenerator(NULL_BODY_GENERATOR)
+                    .build();
     }
 }


### PR DESCRIPTION
Leaves in the bug fix to not set the entity if there is no body generator.
