### PR TITLE
Workaround Cobertura incompatibility with Java 7

### DIFF
--- a/rest-server-base/pom.xml
+++ b/rest-server-base/pom.xml
@@ -327,6 +327,10 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>2.8.1</version>
+                        <!-- Work around Cobertura incompatibilty with Java 7 -->
+                        <configuration>
+                            <argLine>-XX:-UseSplitVerifier</argLine>
+                        </configuration>
                     </plugin>
 
                     <plugin>


### PR DESCRIPTION
For details see:

http://stackoverflow.com/questions/7010665/testng-emma-cobertura-coverage-and-jdk-7-result-in-classformaterror-and-verif
