### PR TITLE
Use System.nanoTime() for measuring time intervals.

### DIFF
--- a/stats/src/main/java/com/proofpoint/stats/ExponentiallyDecayingSample.java
+++ b/stats/src/main/java/com/proofpoint/stats/ExponentiallyDecayingSample.java
@@ -144,7 +144,7 @@ class ExponentiallyDecayingSample
         }
     }
 
-    private long tick() { return System.currentTimeMillis() / 1000; }
+    private static long tick() { return System.nanoTime() / 1_000_000_000; }
 
     private double weight(long t) {
         return exp(alpha * t);
@@ -207,7 +207,7 @@ class ExponentiallyDecayingSample
         Arrays.fill(scores, Double.NaN);
 
         final List<Long> values = this.values();
-        if (values.size() > 0) {
+        if (!values.isEmpty()) {
             Collections.sort(values);
 
             for (int i = 0; i < percentiles.length; i++) {

--- a/stats/src/main/java/com/proofpoint/stats/RealtimeWallClock.java
+++ b/stats/src/main/java/com/proofpoint/stats/RealtimeWallClock.java
@@ -5,6 +5,6 @@ class RealtimeWallClock
 {
     @Override
     public long getMillis() {
-        return System.currentTimeMillis();
+        return System.nanoTime() / 1_000_000;
     }
 }


### PR DESCRIPTION
System.currentTimeMillis() is affected by changes to the system clock, from NTP for example.

Addresses half of issue #132. The http-server half of that issue is complicated because the other half of the interval uses a time created from within Jetty.
