### PR TITLE
Simplify AsyncHttpClient

### DIFF
--- a/http-client/src/main/java/com/proofpoint/http/client/AsyncHttpClient.java
+++ b/http-client/src/main/java/com/proofpoint/http/client/AsyncHttpClient.java
@@ -20,8 +20,7 @@ import com.google.common.util.concurrent.CheckedFuture;
 public interface AsyncHttpClient
         extends HttpClient
 {
-    <T, E extends Exception> AsyncHttpResponseFuture<T, E> executeAsync(Request request, ResponseHandler<T, E> responseHandler)
-            throws E;
+    <T, E extends Exception> AsyncHttpResponseFuture<T, E> executeAsync(Request request, ResponseHandler<T, E> responseHandler);
 
     public interface AsyncHttpResponseFuture<T, E extends Exception>
             extends CheckedFuture<T, E>

--- a/http-client/src/main/java/com/proofpoint/http/client/netty/NettyAsyncHttpClient.java
+++ b/http-client/src/main/java/com/proofpoint/http/client/netty/NettyAsyncHttpClient.java
@@ -145,7 +145,6 @@ public class NettyAsyncHttpClient
 
     @Override
     public <T, E extends Exception> NettyResponseFuture<T, E> executeAsync(Request request, ResponseHandler<T, E> responseHandler)
-            throws E
     {
         // process the request through the filters
         for (HttpRequestFilter requestFilter : requestFilters) {

--- a/http-client/src/main/java/com/proofpoint/http/client/netty/StandaloneNettyAsyncHttpClient.java
+++ b/http-client/src/main/java/com/proofpoint/http/client/netty/StandaloneNettyAsyncHttpClient.java
@@ -64,7 +64,6 @@ public class StandaloneNettyAsyncHttpClient
 
     @Override
     public <T, E extends Exception> AsyncHttpResponseFuture<T, E> executeAsync(Request request, ResponseHandler<T, E> responseHandler)
-            throws E
     {
         return httpClient.executeAsync(request, responseHandler);
     }


### PR DESCRIPTION
Callers of AsyncHttpClient.executeAsync() shouldn't need to write unnecessary exception handling code around the call. Instead they should rely on any ResponseHandler exception being delivered through the AsyncHttpResponseFuture
