### PR TITLE
The new launcher status command now works for servers started by the old...

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+Platform 0.74
+
+* The new launcher status command now reports a running instance of a server
+  started by the old launcher
+
 Platform 0.73
 
 * Applications can now use Bootstrap.withApplicationDefaults() to specify

--- a/launcher/src/main/java/com/proofpoint/launcher/Main.java
+++ b/launcher/src/main/java/com/proofpoint/launcher/Main.java
@@ -555,6 +555,14 @@ public class Main
                 System.exit(0);
             }
 
+            if (legacyPidFilePath != null) {
+                pidStatus = new LegacyPidFile(legacyPidFilePath).getStatus();
+                if (pidStatus.held) {
+                    System.out.println("Running as " + pidStatus.pid);
+                    System.exit(0);
+                }
+            }
+
             System.out.println("Not running");
             System.exit(STATUS_NOT_RUNNING);
         }


### PR DESCRIPTION
... launcher.
