### PR TITLE
Prevent builds from using obsolete Platform artifacts

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -152,6 +152,15 @@
                                     <exclude>org.eclipse.jetty.orbit:javax.servlet</exclude>
                                     <!-- removed -->
                                     <exclude>com.proofpoint.platform:jmx-http-rpc-experimental</exclude>
+                                    <!-- renamed Platform modules -->
+                                    <exclude>com.proofpoint.platform:discovery-experimental</exclude>
+                                    <exclude>com.proofpoint.platform:event-experimental</exclude>
+                                    <exclude>com.proofpoint.platform:http-client-experimental</exclude>
+                                    <exclude>com.proofpoint.platform:jmx-http-experimental</exclude>
+                                    <exclude>com.proofpoint.platform:rack-experimental</exclude>
+                                    <exclude>com.proofpoint.platform:rack-launcher-experimental</exclude>
+                                    <exclude>com.proofpoint.platform:rack-packaging-experimental</exclude>
+                                    <exclude>com.proofpoint.platform:rack-server-base-experimental</exclude>
                                 </excludes>
                                 <includes>
                                     <!-- whitelist the well numbered guava releases -->


### PR DESCRIPTION
Artifacts that had "-experimental" in their name have been renamed to not have that suffix. Builds should fail up front if the old artifacts are pulled in.
