### PR TITLE
Stop Jackson from using getters as setters.

### DIFF
--- a/json/src/main/java/com/proofpoint/json/ObjectMapperProvider.java
+++ b/json/src/main/java/com/proofpoint/json/ObjectMapperProvider.java
@@ -104,6 +104,7 @@ public class ObjectMapperProvider
         objectMapper.disable(MapperFeature.AUTO_DETECT_SETTERS);
         objectMapper.disable(MapperFeature.AUTO_DETECT_GETTERS);
         objectMapper.disable(MapperFeature.AUTO_DETECT_IS_GETTERS);
+        objectMapper.disable(MapperFeature.USE_GETTERS_AS_SETTERS);
 
         if (jsonSerializers != null || jsonDeserializers != null || keySerializers != null || keyDeserializers != null) {
             SimpleModule module = new SimpleModule(getClass().getName(), new Version(1, 0, 0, null));


### PR DESCRIPTION
This commit is stripped down from airlift/airlift@a7aa030c9d6d6d91c5f55977d481ca0bb9dd8c4b. I don't accept that Jackson should be disabled from accessing private fields/methods, the bug in Jackson that Dain is addressing notwithstanding.

be544688e8a68a9a1ffb1339a85a3827e97ccca7 demonstrates the bug. I think we need to take a practice that Jackson serializers and deserializers should be separate classes when they are asymmetric.
