### PR TITLE
Stop LoggingWriter treating logged data as format strings.

### DIFF
--- a/bootstrap/src/main/java/com/proofpoint/bootstrap/LoggingWriter.java
+++ b/bootstrap/src/main/java/com/proofpoint/bootstrap/LoggingWriter.java
@@ -62,14 +62,14 @@ class LoggingWriter extends StringWriter
                     default:
                     case DEBUG: {
                         if (logger.isDebugEnabled()) {
-                            logger.debug(line);
+                            logger.debug("%s", line);
                         }
                         break;
                     }
 
                     case INFO: {
                         if (logger.isInfoEnabled()) {
-                            logger.info(line);
+                            logger.info("%s", line);
                         }
                         break;
                     }


### PR DESCRIPTION
Fixes #279 
