### PR TITLE
Parent launcher responsible for redirecting stdout/stderr to /dev/null

### DIFF
--- a/launcher/src/main/java/com/proofpoint/launcher/Main.java
+++ b/launcher/src/main/java/com/proofpoint/launcher/Main.java
@@ -306,11 +306,20 @@ public class Main
 
             Process child = null;
             try {
-                child = new ProcessBuilder(javaArgs)
+                ProcessBuilder processBuilder = new ProcessBuilder(javaArgs)
                         .directory(new File(dataDir))
-                        .redirectInput(Processes.NULL_FILE)
-                        .redirectOutput(Redirect.INHERIT)
-                        .redirectError(Redirect.INHERIT)
+                        .redirectInput(Processes.NULL_FILE);
+                if (daemon) {
+                    processBuilder = processBuilder
+                            .redirectOutput(Processes.NULL_FILE)
+                            .redirectError(Processes.NULL_FILE);
+                }
+                else {
+                    processBuilder = processBuilder
+                            .redirectOutput(Redirect.INHERIT)
+                            .redirectError(Redirect.INHERIT);
+                }
+                child = processBuilder
                         .start();
             }
             catch (IOException e) {

--- a/launcher/src/main/java/com/proofpoint/launcher/Processes.java
+++ b/launcher/src/main/java/com/proofpoint/launcher/Processes.java
@@ -22,8 +22,6 @@ import jnr.posix.POSIXHandler;
 import sun.misc.Signal;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
@@ -62,14 +60,6 @@ class Processes
     {
         if (!System.getProperty("os.name").startsWith("Windows")) {
             posix.setsid();
-        }
-
-        try {
-            System.setIn(new FileInputStream(NULL_FILE));
-            System.setOut(new PrintStream(NULL_FILE));
-            System.setErr(new PrintStream(NULL_FILE));
-        }
-        catch (FileNotFoundException ignored) {
         }
     }
 


### PR DESCRIPTION
The previous method of detaching stdout/stderr was ineffective.
