### PR TITLE
Require Maven 3.0.5 for CVE-2013-0253

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -171,7 +171,7 @@
                                     <include>junit:junit:[4.11,)</include>                                </includes>
                             </bannedDependencies>
                             <requireMavenVersion>
-                                <version>3.0.0</version>
+                                <version>3.0.5</version>
                             </requireMavenVersion>
                             <requireJavaVersion>
                                 <version>${project.build.targetJdk}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -46,10 +46,6 @@
         <url>http://github.com/proofpoint/platform/tree/master</url>
     </scm>
 
-    <prerequisites>
-        <maven>3.0</maven>
-    </prerequisites>
-
     <build>
         <pluginManagement>
             <plugins>

--- a/rack-server-base/pom.xml
+++ b/rack-server-base/pom.xml
@@ -39,10 +39,6 @@
         <url>http://github.com/proofpoint/platform/tree/master</url>
     </scm>
 
-    <prerequisites>
-        <maven>3.0</maven>
-    </prerequisites>
-
     <distributionManagement>
         <snapshotRepository>
             <id>sonatype-nexus-snapshots</id>

--- a/rest-server-base/pom.xml
+++ b/rest-server-base/pom.xml
@@ -39,10 +39,6 @@
         <url>http://github.com/proofpoint/platform/tree/master</url>
     </scm>
 
-    <prerequisites>
-        <maven>3.0</maven>
-    </prerequisites>
-
     <profiles>
         <profile>
             <id>child-project-profile</id>


### PR DESCRIPTION
Require Maven 3.0.5 for CVE-2013-0253
