### PR TITLE
Launcher update

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+Platform 1.11
+
+* Library Upgrades
+
+  - jnr-posix to 3.0.9
+
 Platform 1.10
 
 * [Bug] NPE if config class bound both with and without a config prefix.

--- a/launcher/pom.xml
+++ b/launcher/pom.xml
@@ -64,20 +64,7 @@
         <dependency>
             <groupId>com.github.jnr</groupId>
             <artifactId>jnr-posix</artifactId>
-            <version>2.0</version>
-            <!--version 2.1 pulls in a jnr-ffi that pulls in asm 2.x, which conflicts with the
-              asm used by jetty-server-->
-        </dependency>
-        <!--jnr-posix 2.0 dependencies-->
-        <dependency>
-            <groupId>com.github.jnr</groupId>
-            <artifactId>jnr-ffi</artifactId>
-            <version>0.6.0</version>
-        </dependency>
-       <dependency>
-            <groupId>com.github.jnr</groupId>
-            <artifactId>jnr-constants</artifactId>
-            <version>0.8.2</version>
+            <version>3.0.9</version>
         </dependency>
     </dependencies>
 

--- a/launcher/src/main/java/com/proofpoint/launcher/Processes.java
+++ b/launcher/src/main/java/com/proofpoint/launcher/Processes.java
@@ -16,6 +16,7 @@
 package com.proofpoint.launcher;
 
 import com.google.common.collect.ImmutableList;
+import jnr.constants.platform.Errno;
 import jnr.posix.POSIX;
 import jnr.posix.POSIXFactory;
 import jnr.posix.POSIXHandler;
@@ -100,6 +101,12 @@ class Processes
         public void error(jnr.constants.platform.Errno error, String extraData)
         {
             throw new RuntimeException("native error " + error.description() + " " + extraData);
+        }
+
+        @Override
+        public void error(Errno errno, String extraData1, String extraData2)
+        {
+            throw new RuntimeException("native error " + errno.description() + " " + extraData1 + " "  + extraData2);
         }
 
         @Override


### PR DESCRIPTION
Updated jnr-posix version in launcher to v3.0.9. This was done because the asm version in launcher which was included by jnr-posix was 3.2, while elasticsearch.jar includes version 4.2, thereby causing a runtime NoSuchMethodError at launcher startup. This update fixes the issue. 