### PR TITLE
Don't leak busy-thread count when exception uncaught

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,9 @@ Platform 1.51
 
 * We suppress logging the thread dump when Bootstrap is in quiet mode.
 
+* [Bug] The HttpServer.BusyThreads.Max metric leaked counts for calls
+  that threw uncaught exceptions.
+
 * Library Upgrades
 
   - Guava to 21.0 (from 20.0)

--- a/http-server/src/main/java/com/proofpoint/http/server/HttpServer.java
+++ b/http-server/src/main/java/com/proofpoint/http/server/HttpServer.java
@@ -132,13 +132,16 @@ public class HttpServer
         requireNonNull(detailedRequestStats, "detailedRequestStats is null");
 
         QueuedThreadPool threadPool = new QueuedThreadPool(config.getMaxThreads()) {
-
             @Override
             protected void runJob(Runnable job)
             {
-                busyThreads.add(1);
-                super.runJob(job);
-                busyThreads.add(-1);
+                try {
+                    busyThreads.add(1);
+                    super.runJob(job);
+                }
+                finally {
+                    busyThreads.add(-1);
+                }
             }
         };
         threadPool.setMinThreads(config.getMinThreads());


### PR DESCRIPTION
Don't leak busy-thread count when exception uncaught