### PR TITLE
Don't have Platform ExceptionMappers pick up media types from resource method annotations.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,9 @@ Platform 1.51
 * [Bug] The HttpServer.BusyThreads.Max metric leaked counts for calls
   that threw uncaught exceptions.
 
+* [Bug] Fixed the Platform-provided ExceptionMapper classes to not pick up
+  media types from the resource method annotations.
+
 * Library Upgrades
 
   - Guava to 21.0 (from 20.0)

--- a/jaxrs/src/main/java/com/proofpoint/jaxrs/ParsingExceptionMapper.java
+++ b/jaxrs/src/main/java/com/proofpoint/jaxrs/ParsingExceptionMapper.java
@@ -15,6 +15,7 @@
  */
 package com.proofpoint.jaxrs;
 
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
@@ -29,6 +30,7 @@ public class ParsingExceptionMapper implements ExceptionMapper<ParsingException>
     public Response toResponse(ParsingException e)
     {
         return Response.status(Response.Status.BAD_REQUEST)
+                .type(MediaType.TEXT_PLAIN_TYPE)
                 .entity(e.getMessage())
                 .build();
     }

--- a/jaxrs/src/main/java/com/proofpoint/jaxrs/QueryParamExceptionMapper.java
+++ b/jaxrs/src/main/java/com/proofpoint/jaxrs/QueryParamExceptionMapper.java
@@ -17,6 +17,7 @@ package com.proofpoint.jaxrs;
 
 import org.glassfish.jersey.server.ParamException.QueryParamException;
 
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
@@ -34,6 +35,7 @@ public class QueryParamExceptionMapper implements ExceptionMapper<QueryParamExce
     public Response toResponse(QueryParamException e)
     {
         return Response.status(Response.Status.BAD_REQUEST)
+                .type(MediaType.TEXT_PLAIN_TYPE)
                 .entity(e.getMessage())
                 .build();
     }


### PR DESCRIPTION
Don't have Platform ExceptionMappers pick up media types from resource method annotations.