### PR TITLE
Allow Trace Logging its needed for the slf4j adapter to write trace …

### DIFF
--- a/log/src/main/java/com/proofpoint/log/Level.java
+++ b/log/src/main/java/com/proofpoint/log/Level.java
@@ -3,6 +3,8 @@ package com.proofpoint.log;
 public enum Level
 {
     OFF(java.util.logging.Level.OFF),
+    ALL(java.util.logging.Level.ALL),
+    TRACE(java.util.logging.Level.FINEST),
     DEBUG(java.util.logging.Level.FINE),
     INFO(java.util.logging.Level.INFO),
     WARN(java.util.logging.Level.WARNING),
@@ -36,6 +38,12 @@ public enum Level
         if (levelValue >= java.util.logging.Level.INFO.intValue()) {
             return INFO;
         }
-        return DEBUG;
+        if (levelValue >= java.util.logging.Level.FINE.intValue()) {
+            return DEBUG;
+        }
+        if (levelValue >= java.util.logging.Level.FINEST.intValue()) {
+            return TRACE;
+        }
+        return ALL;
     }
 }

--- a/log/src/main/java/com/proofpoint/log/Logger.java
+++ b/log/src/main/java/com/proofpoint/log/Logger.java
@@ -22,6 +22,7 @@ import java.util.IllegalFormatException;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.FINEST;
 import static java.util.logging.Level.INFO;
 import static java.util.logging.Level.SEVERE;
 import static java.util.logging.Level.WARNING;
@@ -57,6 +58,34 @@ public class Logger
     {
         java.util.logging.Logger logger = java.util.logging.Logger.getLogger(name);
         return new Logger(logger);
+    }
+
+    /**
+     * Logs a message at TRACE level.
+     * <p>
+     * Usage example:
+     * <pre>
+     *    logger.trace("value is %s (%d ms)", value, time);
+     * </pre>
+     * If the format string is invalid or the arguments are insufficient, an error will be logged and execution
+     * will continue.
+     *
+     * @param format a format string compatible with String.format()
+     * @param args arguments for the format string
+     */
+    public void trace(String format, Object... args)
+    {
+        if (logger.isLoggable(FINEST)) {
+            String message;
+            try {
+                message = format(format, args);
+            }
+            catch (IllegalFormatException e) {
+                logger.log(SEVERE, illegalFormatMessageFor(Level.TRACE, format, args), e);
+                message = rawMessageFor(format, args);
+            }
+            logger.finest(message);
+        }
     }
 
     /**

--- a/log/src/test/java/com/proofpoint/log/TestLogger.java
+++ b/log/src/test/java/com/proofpoint/log/TestLogger.java
@@ -144,6 +144,14 @@ public class TestLogger
     }
 
     @Test
+    public void testTraceShortCircuit()
+    {
+        inner.setLevel(Level.OFF);
+        logger.trace("hello");
+        assertTrue(handler.isEmpty());
+    }
+
+    @Test
     public void testDebugShortCircuit()
     {
         inner.setLevel(Level.OFF);
@@ -210,7 +218,7 @@ public class TestLogger
 
         assertTrue(handler.isEmpty());
     }
-    
+
     @Test
     public void testInsufficientArgsLogsErrorForTrace()
     {

--- a/log/src/test/java/com/proofpoint/log/TestLogger.java
+++ b/log/src/test/java/com/proofpoint/log/TestLogger.java
@@ -60,6 +60,12 @@ public class TestLogger
     @Test
     public void testIsDebugEnabled()
     {
+        inner.setLevel(Level.ALL);
+        assertTrue(logger.isDebugEnabled());
+
+        inner.setLevel(Level.FINEST);
+        assertTrue(logger.isDebugEnabled());
+
         inner.setLevel(Level.FINE);
         assertTrue(logger.isDebugEnabled());
 
@@ -71,6 +77,15 @@ public class TestLogger
 
         inner.setLevel(Level.SEVERE);
         assertFalse(logger.isDebugEnabled());
+    }
+
+    @Test
+    public void testTraceFormat()
+    {
+        inner.setLevel(Level.FINEST);
+        logger.trace("hello, %s", "you");
+
+        assertLog(Level.FINEST, "hello, you");
     }
 
     @Test
@@ -194,6 +209,18 @@ public class TestLogger
         logger.error(e);
 
         assertTrue(handler.isEmpty());
+    }
+    
+    @Test
+    public void testInsufficientArgsLogsErrorForTrace()
+    {
+        String format = "some message: %s, %d";
+        String param = "blah";
+        logger.trace(format, param);
+
+
+        assertLogLike(Level.SEVERE, ImmutableList.of("Invalid format", "TRACE", format, param), IllegalArgumentException.class);
+        assertLog(Level.FINEST, String.format("'%s' [%s]", format, param));
     }
 
 

--- a/log/src/test/java/com/proofpoint/log/TestLogging.java
+++ b/log/src/test/java/com/proofpoint/log/TestLogging.java
@@ -124,6 +124,14 @@ public class TestLogging
         logging.setLevel("testPropagatesLevelsHierarchical", Level.DEBUG);
         assertTrue(logger.isDebugEnabled());
         assertTrue(logger.isInfoEnabled());
+
+        logging.setLevel("testPropagatesLevelsHierarchical", Level.TRACE);
+        assertTrue(logger.isDebugEnabled());
+        assertTrue(logger.isInfoEnabled());
+
+        logging.setLevel("testPropagatesLevelsHierarchical", Level.ALL);
+        assertTrue(logger.isDebugEnabled());
+        assertTrue(logger.isInfoEnabled());
     }
 
     @Test

--- a/log/src/test/java/com/proofpoint/log/TestLogging.java
+++ b/log/src/test/java/com/proofpoint/log/TestLogging.java
@@ -100,6 +100,14 @@ public class TestLogging
         logging.setLevel("testPropagatesLevels", Level.DEBUG);
         assertTrue(logger.isDebugEnabled());
         assertTrue(logger.isInfoEnabled());
+
+        logging.setLevel("testPropagatesLevels", Level.TRACE);
+        assertTrue(logger.isDebugEnabled());
+        assertTrue(logger.isInfoEnabled());
+
+        logging.setLevel("testPropagatesLevels", Level.ALL);
+        assertTrue(logger.isDebugEnabled());
+        assertTrue(logger.isInfoEnabled());
     }
 
     @Test


### PR DESCRIPTION
Adding a Trace and All logging level.
Trace is needed so the slf4j-to-JUL adapter can be set to write TRACE messages to the log.