### PR TITLE
Changed the default value of the http-server.accept-queue-size configuration option to 128 from 8000

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,14 @@
 Platform 1.77
 
+* HttpServer
+
+  We changed the default value of the "http-server.accept-queue-size"
+  configuration option to 128 from 8000. The OS can truncate the accept queue
+  size to the platform defaults. E.g. for linux, the effective server listen
+  backlog queue size cannot be set greater than /proc/sys/net/core/somaxconn
+  on the system. If you feel the need to increase httpAcceptQueueSize, increase
+  the OS limit first.
+
 * Docker
 
   We removed the "combine.children" attribute from the <images> array in the

--- a/http-server/src/main/java/com/proofpoint/http/server/HttpServerConfig.java
+++ b/http-server/src/main/java/com/proofpoint/http/server/HttpServerConfig.java
@@ -49,7 +49,14 @@ public class HttpServerConfig
 {
     private boolean httpEnabled = true;
     private int httpPort = 8080;
-    private int httpAcceptQueueSize = 8000;
+
+    /*
+      The OS can truncate the accept queue size to the platform defaults.
+      E.g. for linux, the effective server listen backlog queue size cannot be set greater
+      than /proc/sys/net/core/somaxconn on the system.
+      If you feel the need to increase httpAcceptQueueSize, increase the OS limit first.
+    */
+    private int httpAcceptQueueSize = 128;
 
     private boolean httpsEnabled = false;
     private int httpsPort = 8443;

--- a/http-server/src/test/java/com/proofpoint/http/server/TestHttpServerConfig.java
+++ b/http-server/src/test/java/com/proofpoint/http/server/TestHttpServerConfig.java
@@ -40,7 +40,7 @@ public class TestHttpServerConfig
         assertRecordedDefaults(ConfigAssertions.recordDefaults(HttpServerConfig.class)
                 .setHttpEnabled(true)
                 .setHttpPort(8080)
-                .setHttpAcceptQueueSize(8000)
+                .setHttpAcceptQueueSize(128)
                 .setHttpsEnabled(false)
                 .setHttpsPort(8443)
                 .setKeystorePath("etc/keystore.jks")


### PR DESCRIPTION
Changed the default value of the "http-server.accept-queue-size" configuration
option to 128 from 8000. The OS can truncate the accept queue size to the platform defaults.
E.g. for linux, the effective server listen backlog queue size cannot be set greater
than /proc/sys/net/core/somaxconn on the system.
