### PR TITLE
#668 Pass requireExplicitBindings flag down to ConfigurationValidator

### DIFF
--- a/bootstrap/src/main/java/com/proofpoint/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/com/proofpoint/bootstrap/Bootstrap.java
@@ -357,7 +357,7 @@ public class Bootstrap
         }
 
         // Validate configuration
-        ConfigurationValidator configurationValidator = new ConfigurationValidator(configurationFactory);
+        ConfigurationValidator configurationValidator = new ConfigurationValidator(configurationFactory, requireExplicitBindings);
         List<Message> messages = configurationValidator.validate(modules);
 
         // Log effective configuration

--- a/bootstrap/src/main/java/com/proofpoint/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/com/proofpoint/bootstrap/Bootstrap.java
@@ -357,6 +357,7 @@ public class Bootstrap
         }
 
         // Validate configuration
+        // If explicit bindings are not required, unused properties will not trigger errors
         ConfigurationValidator configurationValidator = new ConfigurationValidator(configurationFactory, requireExplicitBindings);
         List<Message> messages = configurationValidator.validate(modules);
 

--- a/bootstrap/src/test/java/com/proofpoint/bootstrap/TestBootstrap.java
+++ b/bootstrap/src/test/java/com/proofpoint/bootstrap/TestBootstrap.java
@@ -203,6 +203,40 @@ public class TestBootstrap
     }
 
     @Test
+    public void testFailOnUnusedConfig()
+            throws Exception
+    {
+        System.setProperty("config", Resources.getResource("unused-config.properties").getFile());
+
+        Bootstrap bootstrap = bootstrapApplication("test-application")
+                .doNotInitializeLogging()
+                .withModules((Module) binder -> bindConfig(binder).to(SimpleConfig.class))
+                .quiet();
+
+        try {
+            bootstrap.initialize();
+            fail("should not allow unknown configuration properties");
+        }
+        catch (CreationException e) {
+            assertContains(e.getErrorMessages().iterator().next().getMessage(), "Configuration property 'property2' was not used");
+        }
+    }
+
+    @Test
+    public void testIgnoreUnusedConfig()
+            throws Exception
+    {
+        System.setProperty("config", Resources.getResource("unused-config.properties").getFile());
+
+        Injector injector = bootstrapApplication("test-application")
+                .doNotInitializeLogging()
+                .withModules((Module) binder -> bindConfig(binder).to(SimpleConfig.class))
+                .quiet()
+                .requireExplicitBindings(false)
+                .initialize();
+    }
+
+    @Test
     public void testMissingRequiredConfig()
             throws Exception
     {

--- a/bootstrap/src/test/resources/unused-config.properties
+++ b/bootstrap/src/test/resources/unused-config.properties
@@ -1,0 +1,2 @@
+property=value
+property2=value2

--- a/configuration/src/main/java/com/proofpoint/configuration/ConfigurationValidator.java
+++ b/configuration/src/main/java/com/proofpoint/configuration/ConfigurationValidator.java
@@ -36,6 +36,7 @@ import static java.util.Objects.requireNonNull;
 public class ConfigurationValidator
 {
     private final ConfigurationFactory configurationFactory;
+    private final boolean requireExplicitBindings;
 
     /**
      * @deprecated Use {@link #ConfigurationValidator(ConfigurationFactory)}.
@@ -48,8 +49,14 @@ public class ConfigurationValidator
 
     public ConfigurationValidator(ConfigurationFactory configurationFactory)
     {
+        this(configurationFactory, true);
+    }
+
+    public ConfigurationValidator(ConfigurationFactory configurationFactory, boolean requireExplicitBindings)
+    {
         requireNonNull(configurationFactory, "configurationFactory is null");
         this.configurationFactory = configurationFactory;
+        this.requireExplicitBindings = requireExplicitBindings;
     }
 
     public List<Message> validate(Module... modules)
@@ -110,8 +117,12 @@ public class ConfigurationValidator
 
         for (String unusedProperty : configurationFactory.getUnusedProperties()) {
             final Message message = new Message(format("Configuration property '%s' was not used", unusedProperty));
-            messages.add(message);
-            configurationFactory.getMonitor().onError(message);
+            if(requireExplicitBindings) {
+                messages.add(message);
+                configurationFactory.getMonitor().onError(message);
+            } else {
+                configurationFactory.getMonitor().onWarning(message);
+            }
         }
 
         return messages;


### PR DESCRIPTION
#668: Passed the requireExplicitBindings flag down to Configuration Validator to switch between registering unused properties as errors or warnings