### PR TITLE
#670: Added optional local-config file

### DIFF
--- a/bootstrap/src/main/java/com/proofpoint/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/com/proofpoint/bootstrap/Bootstrap.java
@@ -329,6 +329,7 @@ public class Bootstrap
             log.info("Loading configuration");
             builder = builder
                     .withFile(System.getProperty("config"))
+                    .withOptionalFile(System.getProperty("local-config"))
                     .withFile(System.getProperty("secrets-config"))
                     .withSystemProperties();
         }

--- a/configuration/src/main/java/com/proofpoint/configuration/ConfigurationFactoryBuilder.java
+++ b/configuration/src/main/java/com/proofpoint/configuration/ConfigurationFactoryBuilder.java
@@ -20,10 +20,7 @@ import com.google.inject.spi.Message;
 import com.proofpoint.configuration.Problems.Monitor;
 
 import javax.annotation.Nullable;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -78,6 +75,23 @@ public final class ConfigurationFactoryBuilder
         mergeProperties(properties);
         expectToUse.addAll(properties.stringPropertyNames());
         return this;
+    }
+
+    /**
+     +     * Loads properties from the given file
+     +     *
+     +     * @param path file path
+     +     * @return self
+     +     * @throws java.io.IOException errors
+     +     */
+    public ConfigurationFactoryBuilder withOptionalFile(@Nullable final String path)
+            throws IOException
+    {
+        if (path == null || !(new File(path).exists())) {
+            return this;
+        }
+
+        return withFile(path);
     }
 
     public ConfigurationFactoryBuilder withSystemProperties()

--- a/configuration/src/main/java/com/proofpoint/configuration/ConfigurationFactoryBuilder.java
+++ b/configuration/src/main/java/com/proofpoint/configuration/ConfigurationFactoryBuilder.java
@@ -20,7 +20,11 @@ import com.google.inject.spi.Message;
 import com.proofpoint.configuration.Problems.Monitor;
 
 import javax.annotation.Nullable;
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/configuration/src/main/java/com/proofpoint/configuration/ConfigurationFactoryBuilder.java
+++ b/configuration/src/main/java/com/proofpoint/configuration/ConfigurationFactoryBuilder.java
@@ -78,12 +78,12 @@ public final class ConfigurationFactoryBuilder
     }
 
     /**
-     +     * Loads properties from the given file
-     +     *
-     +     * @param path file path
-     +     * @return self
-     +     * @throws java.io.IOException errors
-     +     */
+     * Optionally loads properties from the given file
+     *
+     * @param path file path
+     * @return self
+     * @throws java.io.IOException errors
+     */
     public ConfigurationFactoryBuilder withOptionalFile(@Nullable final String path)
             throws IOException
     {


### PR DESCRIPTION
Added additional property for local-config, where developer can set their local configuration property file to override settings in the repo config.properties file

Can be set at launch with -Dlocal-config=etc/local.properties