### PR TITLE
Use async appender to log events

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 Platform 1.84
 
+* Logging
+
+  We added an in-memory buffer to reduce locking contention around logging.
+
 * Library Upgrades
 
   - Base docker image to 8u171-jdk (was 8u162-jdk)

--- a/audit/src/test/java/com/proofpoint/audit/TestFileAuditLogger.java
+++ b/audit/src/test/java/com/proofpoint/audit/TestFileAuditLogger.java
@@ -71,6 +71,7 @@ public class TestFileAuditLogger
     {
         TraceTokenManager.clearRequestToken();
         handler.audit(new AutoValue_TestFileAuditLogger_TestingRecord("foovalue"));
+        factory.close();
         String actual = Files.asCharSource(file, UTF_8).read();
         assertEquals(actual, "{\"time\":\"" + ISO_INSTANT.format(dateTimeSupplier.get()) + "\"," +
                 "\"type\":\"com.proofpoint.audit.TestFileAuditLogger.TestingRecord\",\"foo\":\"foovalue\"}\n");
@@ -83,6 +84,7 @@ public class TestFileAuditLogger
         try {
             TraceTokenManager.createAndRegisterNewRequestToken("property", "value");
             handler.audit(new AutoValue_TestFileAuditLogger_TestingRecord("foovalue"));
+            factory.close();
             String actual = Files.asCharSource(file, UTF_8).read();
             assertEquals(actual, "{\"time\":\"" + ISO_INSTANT.format(dateTimeSupplier.get()) + "\"," +
                     "\"type\":\"com.proofpoint.audit.TestFileAuditLogger.TestingRecord\"," +

--- a/http-server/src/main/java/com/proofpoint/http/server/DelimitedRequestLog.java
+++ b/http-server/src/main/java/com/proofpoint/http/server/DelimitedRequestLog.java
@@ -63,9 +63,7 @@ class DelimitedRequestLog
         long currentTime = currentTimeMillisProvider.getCurrentTimeMillis();
         HttpRequestEvent event = createHttpRequestEvent(request, response, currentTime, clientAddressExtractor);
 
-        synchronized (appender) {
-            appender.doAppend(event);
-        }
+        appender.doAppend(event);
     }
 
     @Override

--- a/http-server/src/main/java/com/proofpoint/http/server/JsonRequestLog.java
+++ b/http-server/src/main/java/com/proofpoint/http/server/JsonRequestLog.java
@@ -54,9 +54,7 @@ class JsonRequestLog
         long currentTime = currentTimeMillisProvider.getCurrentTimeMillis();
         HttpRequestEvent event = createHttpRequestEvent(request, response, currentTime, clientAddressExtractor);
 
-        synchronized (appender) {
-            appender.doAppend(event);
-        }
+        appender.doAppend(event);
     }
 
     @Override

--- a/http-server/src/test/java/com/proofpoint/http/server/AbstractTestRequestLog.java
+++ b/http-server/src/test/java/com/proofpoint/http/server/AbstractTestRequestLog.java
@@ -23,6 +23,7 @@ import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.component.LifeCycle;
 import org.mockito.Mock;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -71,9 +72,6 @@ public abstract class AbstractTestRequestLog
 
     protected abstract void setup(HttpServerConfig httpServerConfig)
             throws IOException;
-
-    protected abstract void stopLogger()
-            throws Exception;
 
     protected abstract String getExpectedLogLine(long timestamp, String clientAddr, String method, String pathQuery, String user, String agent, int responseCode, long requestSize, long responseSize, long timeToLastByte);
 
@@ -146,7 +144,7 @@ public abstract class AbstractTestRequestLog
             throws Exception
     {
         logger.log(request, response);
-        stopLogger();
+        ((LifeCycle) logger).stop();
 
         String actual = Files.asCharSource(file, UTF_8).read();
         String expected = getExpectedLogLine(timestamp, "9.9.9.9", method, pathQuery, user, agent, responseCode, requestSize, responseSize, currentTime - request.getTimeStamp());

--- a/http-server/src/test/java/com/proofpoint/http/server/TestDelimitedRequestLog.java
+++ b/http-server/src/test/java/com/proofpoint/http/server/TestDelimitedRequestLog.java
@@ -33,12 +33,6 @@ public class TestDelimitedRequestLog extends AbstractTestRequestLog
     }
 
     @Override
-    protected void stopLogger()
-    {
-        ((DelimitedRequestLog)logger).stop();
-    }
-
-    @Override
     protected String getExpectedLogLine(long timestamp, String clientAddr, String method, String pathQuery, String user, String agent, int responseCode, long requestSize, long responseSize, long timeToLastByte)
     {
         return String.format("%s\t%s\t%s\t%s\t%s\t%s\t%d\t%d\t%d\t%d\t%s\n",

--- a/http-server/src/test/java/com/proofpoint/http/server/TestJsonRequestLog.java
+++ b/http-server/src/test/java/com/proofpoint/http/server/TestJsonRequestLog.java
@@ -37,12 +37,6 @@ public class TestJsonRequestLog extends AbstractTestRequestLog
     }
 
     @Override
-    protected void stopLogger()
-    {
-        ((JsonRequestLog) logger).stop();
-    }
-
-    @Override
     protected String getExpectedLogLine(long timestamp, String clientAddr, String method, String pathQuery, String user, String agent, int responseCode, long requestSize, long responseSize, long timeToLastByte)
     {
         return String.format("{\"time\":\"%s\",\"traceToken\":\"%s\",\"sourceIp\":\"%s\"," +


### PR DESCRIPTION
Logging events while holding a thread from a thread pool can quickly
drain the pool given IO is in general slow. Use async appender to fast
release the thread if applicable. Also, increase the buffer size of the
appender from 8KB to 1MB.