### PR TITLE
Fix configuration of maven-javadoc-plugin

### DIFF
--- a/http-client/src/main/java/com/proofpoint/http/client/ResponseHandler.java
+++ b/http-client/src/main/java/com/proofpoint/http/client/ResponseHandler.java
@@ -17,9 +17,25 @@ package com.proofpoint.http.client;
 
 public interface ResponseHandler<T, E extends Exception>
 {
+    /**
+     * Map an exception that was thrown during processing of a request.
+     *
+     * @param request The request
+     * @param exception The exception that was thrown
+     * @return The value to return to the caller
+     * @throws E The exception to propagate to the caller
+     */
     T handleException(Request request, Exception exception)
             throws E;
 
+    /**
+     * Convert a response into a return value.
+     *
+     * @param request The request
+     * @param response The response
+     * @return The value to return to the caller
+     * @throws E The exception to propagate to the caller
+     */
     T handle(Request request, Response response)
             throws E;
 }

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -277,7 +277,7 @@
                         <source>${project.build.targetJdk}</source>
                         <encoding>${project.build.sourceEncoding}</encoding>
                         <maxmemory>${platform.build.jvmsize}</maxmemory>
-                        <additionalOptions>-Xdoclint:${platform.javadoc.lint}</additionalOptions>
+                        <doclint>${platform.javadoc.lint}</doclint>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
The older version of Maven that was running on Jenkins couldn't deal with that additionalOptions syntax.