### PR TITLE
fix file permission for the token file

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -34,6 +34,8 @@ Platform 1.86
 
 * We added a dependencyManagement section for guava-testlib to the library pom.
 
+* [Bug] Specify permissions for SL_TOKEN_FILE
+
 * Library Upgrades
 
   - Guava to 26.0-jre (was 25.0-jre)

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -1678,6 +1678,7 @@
                                                     <file>
                                                         <source>${SL_TOKEN_FILE}</source>
                                                         <destName>sl-token.txt</destName>
+                                                        <fileMode>0644</fileMode>
                                                         <outputDirectory>lib/</outputDirectory>
                                                     </file>
                                                 </files>


### PR DESCRIPTION
The file permissions is needed to ensure the file is readable.