### PR TITLE
Update modernizer-maven-plugin to v1.7.1 to work with java 11

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -476,7 +476,7 @@
                 <plugin>
                     <groupId>org.gaul</groupId>
                     <artifactId>modernizer-maven-plugin</artifactId>
-                    <version>1.7.0</version>
+                    <version>1.7.1</version>
                     <configuration>
                         <skip>${platform.check.skip-modernizer}</skip>
                         <failOnViolations>${platform.check.fail-modernizer}</failOnViolations>


### PR DESCRIPTION
1.7.0 didn't work with Java 11 so updated to 1.7.1 as per https://github.com/gaul/modernizer-maven-plugin/issues/81