### PR TITLE
Don't override audit log path in launcher

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,10 @@
+Platform 2.17
+
+* Audit Logging
+
+  - The default value for "audit.log.path" has changed to "var/log/audit.log".
+    To disable audit logging, use the new config option "audit.log.enable".
+
 Platform 2.16
 
 * Library Upgrades

--- a/CHANGES
+++ b/CHANGES
@@ -3,7 +3,8 @@ Platform 2.17
 * Audit Logging
 
   - The default value for "audit.log.path" has changed to "var/log/audit.log".
-    To disable audit logging, use the new config option "audit.log.enable".
+    This config option is no longer overridden by the launcher. To disable
+    audit logging, use the new config option "audit.log.enable".
 
 Platform 2.16
 

--- a/audit/src/main/java/com/proofpoint/audit/AuditConfiguration.java
+++ b/audit/src/main/java/com/proofpoint/audit/AuditConfiguration.java
@@ -22,10 +22,24 @@ import com.proofpoint.units.DataSize.Unit;
 
 public class AuditConfiguration
 {
-    private String logPath = null;
+    private boolean logEnable = true;
+    private String logPath = "var/log/audit.log";
     private DataSize maxSegmentSize = new DataSize(100, Unit.MEGABYTE);
     private int maxHistory = 30;
     private DataSize maxTotalSize = new DataSize(1, Unit.GIGABYTE);
+
+
+    public boolean isLogEnable()
+    {
+        return logEnable;
+    }
+
+    @Config("audit.log.enable")
+    public AuditConfiguration setLogEnable(boolean logEnable)
+    {
+        this.logEnable = logEnable;
+        return this;
+    }
 
     public String getLogPath()
     {

--- a/audit/src/main/java/com/proofpoint/audit/AuditLogModule.java
+++ b/audit/src/main/java/com/proofpoint/audit/AuditLogModule.java
@@ -26,7 +26,7 @@ public class AuditLogModule
     protected void setup(Binder binder)
     {
         AuditConfiguration config = buildConfigObject(AuditConfiguration.class);
-        if (config.getLogPath() == null) {
+        if (!config.isLogEnable()) {
             binder.bind(AuditLoggerFactory.class).to(NullAuditLoggerFactory.class).asEagerSingleton();
         }
         else {

--- a/audit/src/test/java/com/proofpoint/audit/TestAuditConfiguration.java
+++ b/audit/src/test/java/com/proofpoint/audit/TestAuditConfiguration.java
@@ -14,7 +14,8 @@ public class TestAuditConfiguration
     public void testDefaults()
     {
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(AuditConfiguration.class)
-                .setLogPath(null)
+                .setLogEnable(true)
+                .setLogPath("var/log/audit.log")
                 .setMaxSegmentSize(new DataSize(100, Unit.MEGABYTE))
                 .setMaxHistory(30)
                 .setMaxTotalSize(new DataSize(1, Unit.GIGABYTE))
@@ -25,6 +26,7 @@ public class TestAuditConfiguration
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("audit.log.enable", "false")
                 .put("audit.log.path", "var/log/foo.log")
                 .put("audit.log.max-size", "1GB")
                 .put("audit.log.max-history", "25")
@@ -32,6 +34,7 @@ public class TestAuditConfiguration
                 .build();
 
         AuditConfiguration expected = new AuditConfiguration()
+                .setLogEnable(false)
                 .setLogPath("var/log/foo.log")
                 .setMaxSegmentSize(new DataSize(1, Unit.GIGABYTE))
                 .setMaxHistory(25)

--- a/audit/src/test/java/com/proofpoint/audit/TestAuditLogModule.java
+++ b/audit/src/test/java/com/proofpoint/audit/TestAuditLogModule.java
@@ -39,6 +39,7 @@ public class TestAuditLogModule
                         new AuditLogModule(),
                         binder -> auditLoggerBinder(binder).bind(TestingRecord.class)
                 )
+                .setRequiredConfigurationProperty("audit.log.enable", "false")
                 .initialize();
         AuditLogger<TestingRecord> auditLogger = injector.getInstance(Key.get(new TypeLiteral<AuditLogger<TestingRecord>>() {}));
         auditLogger.audit(new TestingRecord());

--- a/launcher/src/main/java/com/proofpoint/launcher/Main.java
+++ b/launcher/src/main/java/com/proofpoint/launcher/Main.java
@@ -132,9 +132,6 @@ public final class Main
         @Option(type = OptionType.GLOBAL, name = "--bootstrap-log-file", description = "Path to bootstrap log file. Defaults to DATA_DIR/var/log/bootstrap.log")
         public String bootstrapLogPath = null;
 
-        @Option(type = OptionType.GLOBAL, name = "--audit-log-file", description = "Path to audit log file. Defaults to DATA_DIR/var/log/audit.log")
-        public String auditLogPath = null;
-
         @Option(type = OptionType.GLOBAL, name = "-D", description = "Set a Java System property")
         public final List<String> property = new ArrayList<>();
 
@@ -321,13 +318,6 @@ public final class Main
                 launcherArgs.add("--log-file");
                 launcherArgs.add(new File(logPath).getAbsolutePath());
             }
-            if (auditLogPath == null) {
-                auditLogPath = dataDir + "/var/log/audit.log";
-            }
-            else {
-                launcherArgs.add("--audit-log-file");
-                launcherArgs.add(new File(auditLogPath).getAbsolutePath());
-            }
             if (bootstrapLogPath == null) {
                 bootstrapLogPath = dataDir + "/var/log/bootstrap.log";
             }
@@ -501,7 +491,6 @@ public final class Main
             if (new File(logLevelsPath).exists()) {
                 javaArgs.add("-Dlog.levels-file=" + logLevelsPath);
             }
-            javaArgs.add("-Daudit.log.path=" + auditLogPath);
             javaArgs.add("-Dlog.bootstrap.path=" + bootstrapLogPath);
             javaArgs.add("-jar");
             javaArgs.add(installPath + "/lib/launcher.jar");


### PR DESCRIPTION
Some use cases for changing the path within a Docker container.