### PR TITLE
Fixes #781 - Moving docker build configuration to the build/push execution in the docker plugin

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ Platform 2.19
 
 * Library Upgrades
   - Jetty to 9.4.24 (was 9.4.21)
+  - Docker build/push configuration moved to the default-cli execution
 
 Platform 2.18
 

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -99,8 +99,8 @@
         <connection>scm:git:git://github.com/proofpoint/platform.git</connection>
         <developerConnection>scm:git:git@github.com:proofpoint/platform.git</developerConnection>
         <url>http://github.com/proofpoint/platform/tree/master</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <build>
         <pluginManagement>
@@ -147,7 +147,7 @@
                         <fail>${platform.check.fail-enforcer}</fail>
                         <failFast>false</failFast>
                         <rules>
-                            <requirePluginVersions />
+                            <requirePluginVersions/>
                             <bannedDependencies>
                                 <excludes>
                                     <!-- clashes with commons-logging:commons-logging -->
@@ -180,10 +180,11 @@
                                     <!-- whitelist the well numbered guava releases -->
                                     <include>com.google.guava:guava:[10.0.1,)</include>
                                     <!-- newer versions of junit do not repackage hamcrest -->
-                                    <include>junit:junit:[4.11,)</include>                                </includes>
+                                    <include>junit:junit:[4.11,)</include>
+                                </includes>
                             </bannedDependencies>
-                            <banDuplicatePomDependencyVersions />
-                            <requireUpperBoundDeps />
+                            <banDuplicatePomDependencyVersions/>
+                            <requireUpperBoundDeps/>
                             <requireMavenVersion>
                                 <version>3.2.3</version>
                             </requireMavenVersion>
@@ -1432,7 +1433,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-dependency-plugin</artifactId>
-            			<version>3.1.1</version>
+                        <version>3.1.1</version>
                         <executions>
                             <execution>
                                 <id>unpack launcher</id>
@@ -1474,96 +1475,96 @@
                             <defaultUsername>root</defaultUsername>
                             <defaultGroupname>root</defaultGroupname>
                             <mappings combine.children="append">
-                            <!-- Root directory and README -->
-                                 <mapping>
-                                     <directory>/opt/proofpoint/${project.artifactId}</directory>
-                                     <directoryIncluded>true</directoryIncluded>
-                                     <sources>
-                                         <source>
-                                             <location>README.txt</location>
-                                         </source>
-                                     </sources>
-                                 </mapping>
-                            <!-- Launch scripts (copied from the dir that was unpacked by the dependency plugin) -->
-                                 <mapping>
-                                     <directory>/opt/proofpoint/${project.artifactId}/bin</directory>
-                                     <directoryIncluded>true</directoryIncluded>
-                                     <sources>
-                                         <source>
-                                             <location>${project.build.directory}/launcher/bin</location>
-                                             <excludes>
-                                                 <exclude>**/init.redhat</exclude>
-                                                 <exclude>**/platform.service</exclude>
-                                             </excludes>
-                                         </source>
-                                         <source>
-                                             <location>${project.build.directory}/launcher/bin/init.redhat</location>
-                                             <filter>true</filter>
-                                         </source>
-                                     </sources>
-                                     <username>root</username>
-                                     <groupname>root</groupname>
-                                     <filemode>755</filemode>
-                                 </mapping>
-                            <!-- Service control -->
-                                 <mapping>
-                                     <directory>/etc/init.d</directory>
-                                     <directoryIncluded>false</directoryIncluded>
-                                     <sources>
-                                         <softlinkSource>
-                                             <location>/opt/proofpoint/${project.artifactId}/bin/init.redhat</location>
-                                             <destination>${project.artifactId}</destination>
-                                         </softlinkSource>
-                                     </sources>
-                                     <username>root</username>
-                                     <groupname>root</groupname>
-                                     <filemode>755</filemode>
-                                 </mapping>
-                                 <mapping>
-                                     <directory>/usr/lib/systemd/system</directory>
-                                     <directoryIncluded>false</directoryIncluded>
-                                     <sources>
-                                         <source>
-                                             <location>${project.build.directory}/launcher/bin/platform.service</location>
-                                             <destination>${project.artifactId}.service</destination>
-                                             <filter>true</filter>
-                                         </source>
-                                     </sources>
-                                     <username>root</username>
-                                     <groupname>root</groupname>
-                                     <filemode>644</filemode>
-                                 </mapping>
-                            <!-- Libraries -->
-                                 <mapping>
-                                     <directory>/opt/proofpoint/${project.artifactId}/lib</directory>
-                                     <directoryIncluded>true</directoryIncluded>
-                                     <dependency />
-                                     <!-- Manually include the JAR containing the application code -->
-                                     <sources>
-                                         <source>
-                                             <location>${project.build.directory}/${project.artifactId}-${project.version}.jar</location>
-                                             <destination>main.jar</destination>
-                                         </source>
-                                         <source>
-                                             <location>${project.build.directory}/launcher/lib/launcher.jar</location>
-                                             <destination>launcher.jar</destination>
-                                         </source>
-                                     </sources>
-                                 </mapping>
-                            <!-- Configuration directory should be owned by this package -->
-                                 <mapping>
-                                     <directory>/opt/proofpoint/${project.artifactId}/etc</directory>
-                                     <directoryIncluded>true</directoryIncluded>
-                                     <configuration>noreplace</configuration>
-                                 </mapping>
-                            <!-- local output directory for logging and so on -->
-                                 <mapping>
-                                     <directory>/opt/proofpoint/${project.artifactId}/var</directory>
-                                     <directoryIncluded>true</directoryIncluded>
-                                     <username>${project.rpm.username}</username>
-                                     <groupname>${project.rpm.username}</groupname>
-                                     <filemode>755</filemode>
-                                 </mapping>
+                                <!-- Root directory and README -->
+                                <mapping>
+                                    <directory>/opt/proofpoint/${project.artifactId}</directory>
+                                    <directoryIncluded>true</directoryIncluded>
+                                    <sources>
+                                        <source>
+                                            <location>README.txt</location>
+                                        </source>
+                                    </sources>
+                                </mapping>
+                                <!-- Launch scripts (copied from the dir that was unpacked by the dependency plugin) -->
+                                <mapping>
+                                    <directory>/opt/proofpoint/${project.artifactId}/bin</directory>
+                                    <directoryIncluded>true</directoryIncluded>
+                                    <sources>
+                                        <source>
+                                            <location>${project.build.directory}/launcher/bin</location>
+                                            <excludes>
+                                                <exclude>**/init.redhat</exclude>
+                                                <exclude>**/platform.service</exclude>
+                                            </excludes>
+                                        </source>
+                                        <source>
+                                            <location>${project.build.directory}/launcher/bin/init.redhat</location>
+                                            <filter>true</filter>
+                                        </source>
+                                    </sources>
+                                    <username>root</username>
+                                    <groupname>root</groupname>
+                                    <filemode>755</filemode>
+                                </mapping>
+                                <!-- Service control -->
+                                <mapping>
+                                    <directory>/etc/init.d</directory>
+                                    <directoryIncluded>false</directoryIncluded>
+                                    <sources>
+                                        <softlinkSource>
+                                            <location>/opt/proofpoint/${project.artifactId}/bin/init.redhat</location>
+                                            <destination>${project.artifactId}</destination>
+                                        </softlinkSource>
+                                    </sources>
+                                    <username>root</username>
+                                    <groupname>root</groupname>
+                                    <filemode>755</filemode>
+                                </mapping>
+                                <mapping>
+                                    <directory>/usr/lib/systemd/system</directory>
+                                    <directoryIncluded>false</directoryIncluded>
+                                    <sources>
+                                        <source>
+                                            <location>${project.build.directory}/launcher/bin/platform.service</location>
+                                            <destination>${project.artifactId}.service</destination>
+                                            <filter>true</filter>
+                                        </source>
+                                    </sources>
+                                    <username>root</username>
+                                    <groupname>root</groupname>
+                                    <filemode>644</filemode>
+                                </mapping>
+                                <!-- Libraries -->
+                                <mapping>
+                                    <directory>/opt/proofpoint/${project.artifactId}/lib</directory>
+                                    <directoryIncluded>true</directoryIncluded>
+                                    <dependency />
+                                    <!-- Manually include the JAR containing the application code -->
+                                    <sources>
+                                        <source>
+                                            <location>${project.build.directory}/${project.artifactId}-${project.version}.jar</location>
+                                            <destination>main.jar</destination>
+                                        </source>
+                                        <source>
+                                            <location>${project.build.directory}/launcher/lib/launcher.jar</location>
+                                            <destination>launcher.jar</destination>
+                                        </source>
+                                    </sources>
+                                </mapping>
+                                <!-- Configuration directory should be owned by this package -->
+                                <mapping>
+                                    <directory>/opt/proofpoint/${project.artifactId}/etc</directory>
+                                    <directoryIncluded>true</directoryIncluded>
+                                    <configuration>noreplace</configuration>
+                                </mapping>
+                                <!-- local output directory for logging and so on -->
+                                <mapping>
+                                    <directory>/opt/proofpoint/${project.artifactId}/var</directory>
+                                    <directoryIncluded>true</directoryIncluded>
+                                    <username>${project.rpm.username}</username>
+                                    <groupname>${project.rpm.username}</groupname>
+                                    <filemode>755</filemode>
+                                </mapping>
                             </mappings>
                             <preinstallScriptlet>
                                 <script>if ! id ${project.rpm.username} &gt;/dev/null ; then exit 1; fi</script>
@@ -1626,81 +1627,87 @@
                         <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>default</id>
+                                <id>default-cli</id>
                                 <goals>
                                     <goal>build</goal>
                                     <goal>push</goal>
                                 </goals>
+
+                                <configuration>
+                                    <verbose>${project.docker.verbose}</verbose>
+                                    <images>
+                                        <image>
+                                            <name>${project.docker.project}/${project.docker.name}:${project.version}
+                                            </name>
+                                            <build>
+                                                <from>${project.docker.from}</from>
+                                                <optimise>true</optimise>
+                                                <runCmds combine.children="append">
+                                                    <run>useradd -M -d /service -u ${project.docker.uid} service</run>
+                                                    <run>mkdir /service/var</run>
+                                                    <run>chown service /service/var</run>
+                                                </runCmds>
+                                                <user>${project.docker.uid}</user>
+                                                <workdir>/service</workdir>
+                                                <assembly>
+                                                    <targetDir>/service</targetDir>
+                                                    <inline>
+                                                        <files combine.children="append">
+                                                            <file>
+                                                                <source>
+                                                                    target/${project.artifactId}-${project.version}.jar
+                                                                </source>
+                                                                <destName>main.jar</destName>
+                                                                <outputDirectory>lib/</outputDirectory>
+                                                            </file>
+                                                        </files>
+                                                        <dependencySets combine.children="append">
+                                                            <dependencySet>
+                                                                <scope>runtime</scope>
+                                                                <useProjectArtifact>false</useProjectArtifact>
+                                                                <outputDirectory>lib/</outputDirectory>
+                                                                <outputFileNameMapping>
+                                                                    ${artifact.artifactId}-${artifact.baseVersion}${dashClassifier?}.${artifact.extension}
+                                                                </outputFileNameMapping>
+                                                                <useTransitiveFiltering>true</useTransitiveFiltering>
+                                                                <includes>
+                                                                    <include>*:jar:*</include>
+                                                                </includes>
+                                                                <excludes>
+                                                                    <exclude>*:zip:*</exclude>
+                                                                </excludes>
+                                                            </dependencySet>
+                                                            <dependencySet>
+                                                                <unpack>true</unpack>
+                                                                <outputDirectory>/</outputDirectory>
+                                                                <includes>
+                                                                    <include>com.proofpoint.platform:launcher</include>
+                                                                </includes>
+                                                                <unpackOptions>
+                                                                    <excludes>
+                                                                        <exclude>bin/init.redhat</exclude>
+                                                                        <exclude>bin/launcher.rb</exclude>
+                                                                        <exclude>bin/platform.service</exclude>
+                                                                    </excludes>
+                                                                </unpackOptions>
+                                                            </dependencySet>
+                                                        </dependencySets>
+                                                    </inline>
+                                                </assembly>
+                                                <cmd>
+                                                    <exec>
+                                                        <arg>/usr/bin/java</arg>
+                                                        <arg>-jar</arg>
+                                                        <arg>/service/lib/launcher.jar</arg>
+                                                        <arg>run</arg>
+                                                    </exec>
+                                                </cmd>
+                                            </build>
+                                        </image>
+                                    </images>
+                                </configuration>
                             </execution>
                         </executions>
-                        <configuration>
-                            <verbose>${project.docker.verbose}</verbose>
-                            <images>
-                                <image>
-                                    <name>${project.docker.project}/${project.docker.name}:${project.version}</name>
-                                    <build>
-                                        <from>${project.docker.from}</from>
-                                        <optimise>true</optimise>
-                                        <runCmds combine.children="append">
-                                            <run>useradd -M -d /service -u ${project.docker.uid} service</run>
-                                            <run>mkdir /service/var</run>
-                                            <run>chown service /service/var</run>
-                                        </runCmds>
-                                        <user>${project.docker.uid}</user>
-                                        <workdir>/service</workdir>
-                                        <assembly>
-                                            <targetDir>/service</targetDir>
-                                            <inline>
-                                                <files combine.children="append">
-                                                    <file>
-                                                        <source>target/${project.artifactId}-${project.version}.jar</source>
-                                                        <destName>main.jar</destName>
-                                                        <outputDirectory>lib/</outputDirectory>
-                                                    </file>
-                                                </files>
-                                                <dependencySets combine.children="append">
-                                                    <dependencySet>
-                                                        <scope>runtime</scope>
-                                                        <useProjectArtifact>false</useProjectArtifact>
-                                                        <outputDirectory>lib/</outputDirectory>
-                                                        <outputFileNameMapping>${artifact.artifactId}-${artifact.baseVersion}${dashClassifier?}.${artifact.extension}</outputFileNameMapping>
-                                                        <useTransitiveFiltering>true</useTransitiveFiltering>
-                                                        <includes>
-                                                            <include>*:jar:*</include>
-                                                        </includes>
-                                                        <excludes>
-                                                            <exclude>*:zip:*</exclude>
-                                                        </excludes>
-                                                    </dependencySet>
-                                                    <dependencySet>
-                                                        <unpack>true</unpack>
-                                                        <outputDirectory>/</outputDirectory>
-                                                        <includes>
-                                                            <include>com.proofpoint.platform:launcher</include>
-                                                        </includes>
-                                                        <unpackOptions>
-                                                            <excludes>
-                                                                <exclude>bin/init.redhat</exclude>
-                                                                <exclude>bin/launcher.rb</exclude>
-                                                                <exclude>bin/platform.service</exclude>
-                                                            </excludes>
-                                                        </unpackOptions>
-                                                    </dependencySet>
-                                                </dependencySets>
-                                            </inline>
-                                        </assembly>
-                                        <cmd>
-                                            <exec>
-                                                <arg>/usr/bin/java</arg>
-                                                <arg>-jar</arg>
-                                                <arg>/service/lib/launcher.jar</arg>
-                                                <arg>run</arg>
-                                            </exec>
-                                        </cmd>
-                                    </build>
-                                </image>
-                            </images>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Im not sure if changing to use the default-cli id will cause any issues with the non C15 pipelines, but it has to be default-cli for c15 since its uses maven docker:push to push the image so the default id wouldnt work in this case. Should we maybe have the same configurstion for both default and default-cli?