### PR TITLE
Fix regression when HttpServer needs to use SNI

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,10 @@
+Platform 2.21
+
+* HttpServer
+
+  We fixed a regression in 2.19 when a Java keystore had multiple cert/key
+  pairs.
+
 Platform 2.20
 
 * HttpClient

--- a/http-client/src/main/java/com/proofpoint/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/com/proofpoint/http/client/jetty/JettyHttpClient.java
@@ -151,7 +151,7 @@ public class JettyHttpClient
 
         creationLocation.fillInStackTrace();
 
-        SslContextFactory sslContextFactory = new SslContextFactory();
+        SslContextFactory sslContextFactory = new SslContextFactory.Client();
         sslContextFactory.setEndpointIdentificationAlgorithm("HTTPS");
         sslContextFactory.setExcludeProtocols();
         sslContextFactory.setIncludeProtocols(ENABLED_PROTOCOLS);

--- a/http-client/src/test/java/com/proofpoint/http/client/AbstractHttpClientTest.java
+++ b/http-client/src/test/java/com/proofpoint/http/client/AbstractHttpClientTest.java
@@ -191,7 +191,8 @@ public abstract class AbstractHttpClientTest
 
             httpConfiguration.addCustomizer(new SecureRequestCustomizer());
 
-            sslContextFactory = new SslContextFactory(keystore);
+            sslContextFactory = new SslContextFactory.Server();
+            sslContextFactory.setKeyStorePath(keystore);
             sslContextFactory.setKeyStorePassword("changeit");
 
             connectionFactories.add(new SslConnectionFactory(sslContextFactory, isJava8 ? "http/1.1" : "alpn"));

--- a/http-server/src/main/java/com/proofpoint/http/server/HttpServer.java
+++ b/http-server/src/main/java/com/proofpoint/http/server/HttpServer.java
@@ -358,7 +358,7 @@ public class HttpServer
 
         configuration.addCustomizer(new SecureRequestCustomizer());
 
-        SslContextFactory sslContextFactory = new SslContextFactory();
+        SslContextFactory sslContextFactory = new SslContextFactory.Server();
         sslContextFactory.setEndpointIdentificationAlgorithm("HTTPS");
         sslContextFactory.setKeyStorePath(config.getKeystorePath());
         sslContextFactory.setKeyStorePassword(config.getKeystorePassword());


### PR DESCRIPTION
I wasn't able to get a unit test to reproduce this.