### PR TITLE
Update platform-zulu from 1.5 to 1.6

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,11 @@
+Platform 2.28
+
+* Library Upgrades
+
+  - Base Docker image to proofpoint/platform-zulu-11:1.6
+     based on azul/zulu-openjdk-debian:11.0.7-11.39.15
+    (was proofpoint/platform-zulu-11:1.5)
+
 Platform 2.27
 
 * Library Upgrades

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -40,7 +40,7 @@
         <project.rpm.username>${project.artifactId}</project.rpm.username>
         <project.docker.project>dev-docker-local</project.docker.project>
         <project.docker.name>%a</project.docker.name>
-        <project.docker.from>docker.io/proofpoint/platform-zulu-11:1.5</project.docker.from>
+        <project.docker.from>docker.io/proofpoint/platform-zulu-11:1.6</project.docker.from>
         <project.docker.uid>1000</project.docker.uid>
         <project.docker.verbose>false</project.docker.verbose>
 


### PR DESCRIPTION
Base image includes the following changes:
- update zulu to 8u252-8.46.0.19 and 11.0.7-11.39.15
- zulu image is now based on bionic
- also pins to specific release for reproducability