### PR TITLE
Update base image platform-zulu-11 from 1.6 to 1.7

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+Platform 2.31
+
+* Library Upgrades
+  - Base Docker image to proofpoint/platform-zulu-11:1.7
+    updates libgnutls30 to 3.6.7-4+deb10u4 for CVE-2020-13777
+
 Platform 2.30
 
 * Library Upgrades

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -39,7 +39,7 @@
         <project.rpm.username>${project.artifactId}</project.rpm.username>
         <project.docker.project>dev-docker-local</project.docker.project>
         <project.docker.name>%a</project.docker.name>
-        <project.docker.from>docker.io/proofpoint/platform-zulu-11:1.6</project.docker.from>
+        <project.docker.from>docker.io/proofpoint/platform-zulu-11:1.7</project.docker.from>
         <project.docker.uid>1000</project.docker.uid>
         <project.docker.verbose>false</project.docker.verbose>
 


### PR DESCRIPTION
Base image includes the following changes:
- update libgnutls30 to 3.6.7-4+deb10u4 from 3.6.7-4+deb10u3 for CVE-2020-13777