### PR TITLE
SonarQube PR analysis integration

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -1774,7 +1774,7 @@
             </activation>
             <properties>
                 <sonar.branch.name>${env.BRANCH_NAME}</sonar.branch.name>
-                <sonar.projectKey>${env.SONAR_PROJECT_KET}</sonar.projectKey>
+                <sonar.projectKey>${env.SONAR_PROJECT_KEY}</sonar.projectKey>
             </properties>
             <build>
                 <plugins>
@@ -1813,7 +1813,7 @@
                 <sonar.pullrequest.key>${env.CHANGE_ID}</sonar.pullrequest.key>
                 <sonar.pullrequest.branch>${env.CHANGE_BRANCH}</sonar.pullrequest.branch>
                 <sonar.pullrequest.base>${env.CHANGE_TARGET}</sonar.pullrequest.base>
-                <sonar.projectKey>${env.SONAR_PROJECT_KET}</sonar.projectKey>
+                <sonar.projectKey>${env.SONAR_PROJECT_KEY}</sonar.projectKey>
             </properties>
             <build>
                 <plugins>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -1763,14 +1763,56 @@
         </profile>
 
         <profile>
-            <id>build-sonar</id>
+            <id>sonar-branch</id>
             <activation>
                 <file>
                     <exists>.build-sonar</exists>
                 </file>
+                <property>
+                    <name>!env.CHANGE_ID</name>
+                </property>
             </activation>
             <properties>
                 <sonar.branch.name>${env.BRANCH_NAME}</sonar.branch.name>
+                <sonar.projectKey>${env.BITBUCKET_PROJECT_KEY}:${env.BITBUCKET_REPO_NAME}</sonar.projectKey>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonarsource.scanner.maven</groupId>
+                        <artifactId>sonar-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sonar-scan-unit-tests</id>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>sonar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>sonar-PR</id>
+            <activation>
+                <file>
+                    <exists>.build-sonar</exists>
+                </file>
+                <property>
+                    <name>env.CHANGE_ID</name>
+                </property>
+            </activation>
+            <properties>
+                <sonar.pullrequest.key>${env.CHANGE_ID}</sonar.pullrequest.key>
+                <sonar.pullrequest.branch>${env.CHANGE_BRANCH}</sonar.pullrequest.branch>
+                <sonar.pullrequest.base>${env.CHANGE_TARGET}</sonar.pullrequest.base>
                 <sonar.projectKey>${env.BITBUCKET_PROJECT_KEY}:${env.BITBUCKET_REPO_NAME}</sonar.projectKey>
             </properties>
             <build>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -1774,7 +1774,7 @@
             </activation>
             <properties>
                 <sonar.branch.name>${env.BRANCH_NAME}</sonar.branch.name>
-                <sonar.projectKey>${env.BITBUCKET_PROJECT_KEY}:${env.BITBUCKET_REPO_NAME}</sonar.projectKey>
+                <sonar.projectKey>${env.SONAR_PROJECT_KET}</sonar.projectKey>
             </properties>
             <build>
                 <plugins>
@@ -1813,7 +1813,7 @@
                 <sonar.pullrequest.key>${env.CHANGE_ID}</sonar.pullrequest.key>
                 <sonar.pullrequest.branch>${env.CHANGE_BRANCH}</sonar.pullrequest.branch>
                 <sonar.pullrequest.base>${env.CHANGE_TARGET}</sonar.pullrequest.base>
-                <sonar.projectKey>${env.BITBUCKET_PROJECT_KEY}:${env.BITBUCKET_REPO_NAME}</sonar.projectKey>
+                <sonar.projectKey>${env.SONAR_PROJECT_KET}</sonar.projectKey>
             </properties>
             <build>
                 <plugins>


### PR DESCRIPTION
LEGO-664, LEGO-624
Adding a new (similar) maven profile to enable SonarQube PR analysis.

CHANGE_ID will be available only on PR, therefore a different set of property will be executed. This will give developers more insights of the quality of PR, and even make them aware of this on the Bitbucket side.