### PR TITLE
Add info section to application OpenApi spec

### DIFF
--- a/jaxrs/src/main/java/com/proofpoint/jaxrs/OpenApiResource.java
+++ b/jaxrs/src/main/java/com/proofpoint/jaxrs/OpenApiResource.java
@@ -33,7 +33,6 @@ public class OpenApiResource extends BaseOpenApiResource
     private final NodeInfo nodeInfo;
     private static final String SWAGGER_JAXRS_ANNOTATION_SCANNER = "io.swagger.v3.oas.integration.GenericOpenApiScanner";
 
-
     @Inject
     public OpenApiResource(@JaxrsResource Set<Object> jaxrsResources, NodeInfo nodeInfo)
     {

--- a/jaxrs/src/main/java/com/proofpoint/jaxrs/OpenApiResource.java
+++ b/jaxrs/src/main/java/com/proofpoint/jaxrs/OpenApiResource.java
@@ -2,10 +2,12 @@ package com.proofpoint.jaxrs;
 
 import com.proofpoint.jaxrs.AccessDoesNotRequireAuthentication;
 import com.proofpoint.jaxrs.JaxrsResource;
+import com.proofpoint.node.NodeInfo;
 import io.swagger.v3.jaxrs2.integration.resources.BaseOpenApiResource;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.integration.SwaggerConfiguration;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -28,12 +30,15 @@ import static java.util.Objects.requireNonNull;
 public class OpenApiResource extends BaseOpenApiResource
 {
     private final Set<Object> jaxrsResources;
+    private final NodeInfo nodeInfo;
     private static final String SWAGGER_JAXRS_ANNOTATION_SCANNER = "io.swagger.v3.oas.integration.GenericOpenApiScanner";
 
+
     @Inject
-    public OpenApiResource(@JaxrsResource Set<Object> jaxrsResources)
+    public OpenApiResource(@JaxrsResource Set<Object> jaxrsResources, NodeInfo nodeInfo)
     {
         this.jaxrsResources = requireNonNull(jaxrsResources, "jaxrsResources is null");
+        this.nodeInfo = nodeInfo;
     }
 
     @GET
@@ -54,8 +59,13 @@ public class OpenApiResource extends BaseOpenApiResource
     @PostConstruct
     void configureSwagger()
     {
+        Info info = new Info();
+        info.setTitle(nodeInfo.getApplication());
+        info.setVersion(nodeInfo.getApplicationVersion());
+        OpenAPI openAPI = new OpenAPI().info(info);
+
         SwaggerConfiguration oasConfig = new SwaggerConfiguration()
-                .openAPI(new OpenAPI())
+                .openAPI(openAPI)
                 .prettyPrint(true);
         oasConfig.setResourceClasses(jaxrsResources.stream().map(classame -> classame.getClass().getName()).collect(Collectors.toSet()));
         oasConfig.setScannerClass(SWAGGER_JAXRS_ANNOTATION_SCANNER);

--- a/jaxrs/src/test/java/com/proofpoint/jaxrs/TestOpenApi.java
+++ b/jaxrs/src/test/java/com/proofpoint/jaxrs/TestOpenApi.java
@@ -80,6 +80,10 @@ public class TestOpenApi
         resourceList.add("TestingResource");
         Object expected = ImmutableMap.of(
                 "openapi", "3.0.1",
+                "info", ImmutableMap.of(
+                        "title", "test-application",
+                        "version", ""
+                ),
                 "paths", ImmutableMap.of(
                         "/", ImmutableMap.of(
                                 "get", ImmutableMap.of(

--- a/jaxrs/src/test/java/com/proofpoint/jaxrs/TestOpenApi.java
+++ b/jaxrs/src/test/java/com/proofpoint/jaxrs/TestOpenApi.java
@@ -82,7 +82,7 @@ public class TestOpenApi
                 "openapi", "3.0.1",
                 "info", ImmutableMap.of(
                         "title", "test-application",
-                        "version", ""
+                        "version", "1.0.0"
                 ),
                 "paths", ImmutableMap.of(
                         "/", ImmutableMap.of(
@@ -181,7 +181,7 @@ public class TestOpenApi
                                                         "content", ImmutableMap.of(
                                                                 "text/plain", ImmutableMap.of(
                                                                         "schema", ImmutableMap.of("type", "string")))))
-                                        ))
+                                ))
                 )
         );
         Object response = client.execute(

--- a/node/src/main/java/com/proofpoint/node/testing/TestingNodeModule.java
+++ b/node/src/main/java/com/proofpoint/node/testing/TestingNodeModule.java
@@ -90,7 +90,7 @@ public class TestingNodeModule
     @Singleton
     NodeInfo createNodeInfo(NodeConfig config)
     {
-        return new NodeInfo("test-application", config);
+        return new NodeInfo("test-application", "1.0.0", "", config);
     }
 
     @SuppressWarnings("ImplicitNumericConversion")


### PR DESCRIPTION
Some of the tools i was using were failing to validate the generated OpenApi spec as the title and version weren't set, so I've added them in.