### PR TITLE
remove creation of service user to remove sh dependency

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 Platform 2.39
 
+* Base image changes
+  - Base Docker image to repocache.nonprod.ppops.net/dev-docker-local/c15-java11:2.13
+  - Base image needs to have the "service" user and /service/var directory
+
 * Packaging
 
   We now exclude test-scope jar files from distribution tar files and

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -39,7 +39,7 @@
         <project.rpm.username>${project.artifactId}</project.rpm.username>
         <project.docker.project>dev-docker-local</project.docker.project>
         <project.docker.name>%a</project.docker.name>
-        <project.docker.from>repocache.nonprod.ppops.net/docker-remote/proofpoint/platform-zulu-11:1.11</project.docker.from>
+        <project.docker.from>repocache.nonprod.ppops.net/dev-docker-local/c15-java11:2.13</project.docker.from>
         <project.docker.uid>1000</project.docker.uid>
         <project.docker.verbose>false</project.docker.verbose>
 
@@ -1696,11 +1696,6 @@
                                     <build>
                                         <from>${project.docker.from}</from>
                                         <optimise>true</optimise>
-                                        <runCmds combine.children="append">
-                                            <run>useradd -M -d /service -u ${project.docker.uid} service</run>
-                                            <run>mkdir /service/var</run>
-                                            <run>chown service /service/var</run>
-                                        </runCmds>
                                         <user>${project.docker.uid}</user>
                                         <workdir>/service</workdir>
                                         <assembly>


### PR DESCRIPTION
service user and /service/var are assumed to be created in the base image