### PR TITLE
Filter test artifacts

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -1726,7 +1726,7 @@
                                                         </includes>
                                                         <excludes>
                                                             <exclude>*:zip:*</exclude>
-                                                            <exclude>*:test:*</exclude>
+                                                            <exclude>*:tests:*</exclude>
                                                         </excludes>
                                                     </dependencySet>
                                                     <dependencySet>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -1726,6 +1726,7 @@
                                                         </includes>
                                                         <excludes>
                                                             <exclude>*:zip:*</exclude>
+                                                            <exclude>*:test:*</exclude>
                                                         </excludes>
                                                     </dependencySet>
                                                     <dependencySet>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -1726,7 +1726,7 @@
                                                         </includes>
                                                         <excludes>
                                                             <exclude>*:zip:*</exclude>
-                                                            <exclude>*:tests:*</exclude>
+                                                            <exclude>*:test-jar:*</exclude>
                                                         </excludes>
                                                     </dependencySet>
                                                     <dependencySet>

--- a/packaging/src/main/resources/assemblies/distribution.xml
+++ b/packaging/src/main/resources/assemblies/distribution.xml
@@ -45,6 +45,7 @@
             </includes>
             <excludes>
                 <exclude>*:zip:*</exclude>
+                <exclude>*:test-jar:*</exclude>
             </excludes>
         </dependencySet>
         <dependencySet>


### PR DESCRIPTION
At present, test-scoped dependencies are included in the final artifact by the "all jars" wildcard.  This PR adds an exclusion for artifacts with the "test-jar" type.

Alternately (or additionally) we could add exclusions for the "tests" classifier.

This has been tested locally on an artifact that was problematically including test jars in the distribution tar.gz, and afterwards the problematic files are absent as expected.