### PR TITLE
Robustify service descriptors

### DIFF
--- a/discovery/src/main/java/com/proofpoint/discovery/client/ServiceDescriptorsUpdater.java
+++ b/discovery/src/main/java/com/proofpoint/discovery/client/ServiceDescriptorsUpdater.java
@@ -110,10 +110,11 @@ public final class ServiceDescriptorsUpdater
                 Duration delay = null;
 
                 // Starting case:  current descriptors null.
-                if(serviceDescriptors.compareAndSet(null, newDescriptors)){
+                if (serviceDescriptors.compareAndSet(null, newDescriptors)) {
                     target.updateServiceDescriptors(newDescriptors.getServiceDescriptors());
                     delay = newDescriptors.getMaxAge();
-                } else if(!newDescriptors.getServiceDescriptors().isEmpty()) {
+                }
+                else if (!newDescriptors.getServiceDescriptors().isEmpty()) {
                     // Typical case:  new descriptors are populated
                     serviceDescriptors.set(newDescriptors);
                     target.updateServiceDescriptors(newDescriptors.getServiceDescriptors());

--- a/discovery/src/main/java/com/proofpoint/discovery/client/ServiceDescriptorsUpdater.java
+++ b/discovery/src/main/java/com/proofpoint/discovery/client/ServiceDescriptorsUpdater.java
@@ -109,13 +109,8 @@ public final class ServiceDescriptorsUpdater
             {
                 Duration delay = null;
 
-                // Starting case:  current descriptors null.
-                if (serviceDescriptors.compareAndSet(null, newDescriptors)) {
-                    target.updateServiceDescriptors(newDescriptors.getServiceDescriptors());
-                    delay = newDescriptors.getMaxAge();
-                }
-                else if (!newDescriptors.getServiceDescriptors().isEmpty()) {
-                    // Typical case:  new descriptors are populated
+                // If we have no current descriptors, or the new descriptors have contents, perform the set.
+                if(serviceDescriptors.get() == null || !newDescriptors.getServiceDescriptors().isEmpty()){
                     serviceDescriptors.set(newDescriptors);
                     target.updateServiceDescriptors(newDescriptors.getServiceDescriptors());
                     delay = newDescriptors.getMaxAge();

--- a/discovery/src/main/java/com/proofpoint/discovery/client/ServiceDescriptorsUpdater.java
+++ b/discovery/src/main/java/com/proofpoint/discovery/client/ServiceDescriptorsUpdater.java
@@ -110,7 +110,7 @@ public final class ServiceDescriptorsUpdater
                 Duration delay = null;
 
                 // If we have no current descriptors, or the new descriptors have contents, perform the set.
-                if(serviceDescriptors.get() == null || !newDescriptors.getServiceDescriptors().isEmpty()){
+                if (serviceDescriptors.get() == null || !newDescriptors.getServiceDescriptors().isEmpty()) {
                     serviceDescriptors.set(newDescriptors);
                     target.updateServiceDescriptors(newDescriptors.getServiceDescriptors());
                     delay = newDescriptors.getMaxAge();

--- a/discovery/src/test/java/com/proofpoint/discovery/client/balancing/TestHttpServiceBalancerListenerAdapter.java
+++ b/discovery/src/test/java/com/proofpoint/discovery/client/balancing/TestHttpServiceBalancerListenerAdapter.java
@@ -124,7 +124,9 @@ public class TestHttpServiceBalancerListenerAdapter
     }
 
     @Test
-    public void testServiceReplacedWithEmptySet() throws InterruptedException {
+    public void testServiceReplacedWithEmptySet()
+            throws InterruptedException
+    {
         discoveryClient.addDiscoveredService(APPLE_1_SERVICE);
 
         // start the updater and verify that we get the initial call
@@ -145,7 +147,9 @@ public class TestHttpServiceBalancerListenerAdapter
     }
 
     @Test
-    public void testServiceReplacedWithNonEmptySet() throws InterruptedException {
+    public void testServiceReplacedWithNonEmptySet()
+            throws InterruptedException
+    {
         discoveryClient.addDiscoveredService(APPLE_1_SERVICE);
 
         // start the updater and verify that we get the initial call

--- a/discovery/src/test/java/com/proofpoint/discovery/client/balancing/TestHttpServiceBalancerListenerAdapter.java
+++ b/discovery/src/test/java/com/proofpoint/discovery/client/balancing/TestHttpServiceBalancerListenerAdapter.java
@@ -31,20 +31,22 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import static com.proofpoint.concurrent.Threads.daemonThreadsNamed;
 import static com.proofpoint.testing.Assertions.assertEqualsIgnoreOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertEquals;
 
 public class TestHttpServiceBalancerListenerAdapter
 {
     private static final ServiceDescriptor APPLE_1_SERVICE = new ServiceDescriptor(UUID.randomUUID(), "node-A", "apple", "pool", "location", ServiceState.RUNNING, ImmutableMap.of("http", "http://apple-a.example.com"));
+    private static final ServiceDescriptor APPLE_1_SERVICE_REPLACEMENT = new ServiceDescriptor(APPLE_1_SERVICE.getId(), "node-A", "apple", "pool", "location", ServiceState.RUNNING, ImmutableMap.of("http", "http://apple-b.example.com"));
     private static final ServiceDescriptor APPLE_2_SERVICE = new ServiceDescriptor(UUID.randomUUID(), "node-B", "apple", "pool", "location", ServiceState.RUNNING, ImmutableMap.of("http", "http://apple-c.example.com", "https", "https://apple-b.example.com"));
     private static final ServiceDescriptor APPLE_2_SERVICE_WEIGHTED = new ServiceDescriptor(UUID.randomUUID(), "node-B", "apple", "pool", "location", ServiceState.RUNNING, ImmutableMap.of("http", "http://apple-c.example.com", "https", "https://apple-b.example.com", "weight", "2.5"));
     private static final ServiceDescriptor DIFFERENT_TYPE = new ServiceDescriptor(UUID.randomUUID(), "node-A", "banana", "pool", "location", ServiceState.RUNNING, ImmutableMap.of("https", "https://banana.example.com"));
@@ -119,6 +121,49 @@ public class TestHttpServiceBalancerListenerAdapter
         verify(httpServiceBalancer).updateHttpUris(captor.capture());
 
         assertEqualsIgnoreOrder(captor.getValue(), ImmutableMultiset.of(URI.create("http://apple-a.example.com"), URI.create("https://apple-b.example.com")));
+    }
+
+    @Test
+    public void testServiceReplacedWithEmptySet() throws InterruptedException {
+        discoveryClient.addDiscoveredService(APPLE_1_SERVICE);
+
+        // start the updater and verify that we get the initial call
+        updater.start();
+        ArgumentCaptor<Multiset> captor = ArgumentCaptor.forClass(Multiset.class);
+        verify(httpServiceBalancer).updateHttpUris(captor.capture());
+
+        // we remove the service we just added.
+        discoveryClient.remove(APPLE_1_SERVICE.getId());
+
+        // a bit on the long side, but this is the default delay to ensure our updater re-triggers.
+        Thread.sleep(10000);
+
+        // verify that even though we removed the service, it was not removed from the balancer.
+        verifyNoMoreInteractions(httpServiceBalancer);
+
+        assertEqualsIgnoreOrder(captor.getValue(), ImmutableMultiset.of(URI.create("http://apple-a.example.com")));
+    }
+
+    @Test
+    public void testServiceReplacedWithNonEmptySet() throws InterruptedException {
+        discoveryClient.addDiscoveredService(APPLE_1_SERVICE);
+
+        // start the updater and verify that we get the initial call
+        updater.start();
+
+        // we replace the service we just added with an updated descriptor for the same ID and node ID.
+        discoveryClient.addDiscoveredService(APPLE_1_SERVICE_REPLACEMENT);
+
+        // a bit on the long side, but this is the default delay to ensure our updater re-triggers.
+        Thread.sleep(10000);
+
+        ArgumentCaptor<Multiset> captor = ArgumentCaptor.forClass(Multiset.class);
+
+        // we verify that our update method is called twice...
+        verify(httpServiceBalancer, times(2)).updateHttpUris(captor.capture());
+
+        // ...and that each time the argument points to the (single) correct URL for that point in time.
+        assertEquals(captor.getAllValues(), Arrays.asList(ImmutableMultiset.of(URI.create("http://apple-a.example.com")), ImmutableMultiset.of(URI.create("http://apple-b.example.com"))));
     }
 
     @Test

--- a/discovery/src/test/java/com/proofpoint/discovery/client/balancing/TestHttpServiceBalancerListenerAdapter.java
+++ b/discovery/src/test/java/com/proofpoint/discovery/client/balancing/TestHttpServiceBalancerListenerAdapter.java
@@ -155,7 +155,7 @@ public class TestHttpServiceBalancerListenerAdapter
         discoveryClient.addDiscoveredService(APPLE_1_SERVICE_REPLACEMENT);
 
         // a bit on the long side, but this is the default delay to ensure our updater re-triggers.
-        Thread.sleep(10000);
+        Thread.sleep(11000);
 
         ArgumentCaptor<Multiset> captor = ArgumentCaptor.forClass(Multiset.class);
 

--- a/discovery/src/test/java/com/proofpoint/discovery/client/balancing/TestHttpServiceBalancerListenerAdapter.java
+++ b/discovery/src/test/java/com/proofpoint/discovery/client/balancing/TestHttpServiceBalancerListenerAdapter.java
@@ -42,7 +42,10 @@ import java.util.concurrent.TimeUnit;
 
 import static com.proofpoint.concurrent.Threads.daemonThreadsNamed;
 import static com.proofpoint.testing.Assertions.assertEqualsIgnoreOrder;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.testng.Assert.assertEquals;
 
 public class TestHttpServiceBalancerListenerAdapter


### PR DESCRIPTION
Once upon a time we had a bug where we got a (mistakenly) empty set of descriptors and tried to run with it, replacing our correct-but-outdated list.  This patch should prevent a recurrence of said bug by allowing us to keep using expired descriptors if somebody tries to replace them with the empty set.  This should be considered a degraded mode of operation, but it's better than failing outright.