### PR TITLE
Fix issue parsing 4+ segment JDK versions like '11.0.9.1'.

### DIFF
--- a/jmx/src/main/java/com/proofpoint/jmx/JavaVersion.java
+++ b/jmx/src/main/java/com/proofpoint/jmx/JavaVersion.java
@@ -28,7 +28,7 @@ import static java.lang.String.format;
 class JavaVersion
 {
     // As described in JEP-223
-    private static final String VERSION_NUMBER = "(?<MAJOR>[1-9][0-9]*)(\\.(?<MINOR>(0|[1-9][0-9]*))(\\.(?:(0|[1-9][0-9]*)))?)?";
+    private static final String VERSION_NUMBER = "(?<MAJOR>[1-9][0-9]*)(\\.(?<MINOR>(0|[1-9][0-9]*))(\\.(?:(0|[1-9][0-9]*)))*)?";
     private static final String PRE = "(?:-(?:[a-zA-Z0-9]+))?";
     private static final String BUILD = "(?:(?:\\+)(?:0|[1-9][0-9]*)?)?";
     private static final String OPT = "(?:-(?:[-a-zA-Z0-9.]+))?";

--- a/jmx/src/test/java/com/proofpoint/jmx/TestJavaVersion.java
+++ b/jmx/src/test/java/com/proofpoint/jmx/TestJavaVersion.java
@@ -42,5 +42,8 @@ public class TestJavaVersion
         assertEquals(JavaVersion.parse("9+100"), new JavaVersion(9, 0));
         assertEquals(JavaVersion.parse("9.0.1+20"), new JavaVersion(9, 0));
         assertEquals(JavaVersion.parse("9.1.1+20"), new JavaVersion(9, 1));
+        assertEquals(JavaVersion.parse("11.0.9"), new JavaVersion(11, 0));
+        assertEquals(JavaVersion.parse("11.0.9.1"), new JavaVersion(11, 0));
+        assertEquals(JavaVersion.parse("11.0.9.1+1-LTS"), new JavaVersion(11, 0));
     }
 }


### PR DESCRIPTION
When running Azul's November Zulu release 11.43, Java version will fail to parse as it has 4 segments `11.0.9.1+1`:

```
1) An exception was caught and reported. Message: Cannot parse version 11.0.9.1
  at com.google.inject.internal.InjectorShell$Builder.build(InjectorShell.java:137)

1 error
	at com.google.inject.internal.Errors.throwCreationExceptionIfErrorsExist(Errors.java:554)
	at com.google.inject.internal.InternalInjectorCreator.initializeStatically(InternalInjectorCreator.java:161)
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:108)
	at com.google.inject.Guice.createInjector(Guice.java:87)
	at com.proofpoint.bootstrap.Bootstrap.initialize(Bootstrap.java:432)
	at com.proofpoint.tapeng.countvoncount.Main.main(Main.java:99)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at com.proofpoint.launcher.Main$LauncherCommand.invokeMain(Main.java:664)
	at com.proofpoint.launcher.Main$RunClientCommand.execute(Main.java:785)
	at com.proofpoint.launcher.Main$LauncherCommand.run(Main.java:326)
	at com.proofpoint.launcher.Main.main(Main.java:96)
Caused by: java.lang.IllegalArgumentException: Cannot parse version 11.0.9.1
	at com.proofpoint.jmx.JavaVersion.parse(JavaVersion.java:76)
	at com.proofpoint.jmx.JavaVersion.current(JavaVersion.java:46)
	at com.proofpoint.jmx.JmxModule.configure(JmxModule.java:42)
	at com.google.inject.spi.Elements$RecordingBinder.install(Elements.java:347)
	at com.google.inject.spi.Elements.getElements(Elements.java:104)
	at com.google.inject.internal.InjectorShell$Builder.build(InjectorShell.java:137)
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:105)
	... 11 more
```