### PR TITLE
Remove dependency on deprecated guice-multibindings

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,10 @@ Platform 2.47
   - maven-site-plugin to 3.9.1 (was 3.9.0)
   - docker-maven-plugin to 0.35.0 (was 0.33.0)
 
+* Library Changes
+
+  - guice-multibindings has been removed as it is no longer a standalone library.
+
 Platform 2.46
 
 * Library Upgrades

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -1010,12 +1010,6 @@
 
             <dependency>
                 <groupId>com.google.inject.extensions</groupId>
-                <artifactId>guice-multibindings</artifactId>
-                <version>${dep.guice.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.google.inject.extensions</groupId>
                 <artifactId>guice-servlet</artifactId>
                 <version>${dep.guice.version}</version>
             </dependency>


### PR DESCRIPTION
As of Guice 5.x, multibindings as a standalone dependency is obsolete/deprecated.  It is now part of Guice itself.