### PR TITLE
log a warning when service descriptors are missing

### DIFF
--- a/discovery/src/main/java/com/proofpoint/discovery/client/ServiceDescriptorsUpdater.java
+++ b/discovery/src/main/java/com/proofpoint/discovery/client/ServiceDescriptorsUpdater.java
@@ -109,14 +109,24 @@ public final class ServiceDescriptorsUpdater
             {
                 Duration delay = null;
 
-                // If we have no current descriptors, or the new descriptors have contents, perform the set.
-                if (serviceDescriptors.get() == null || !newDescriptors.getServiceDescriptors().isEmpty()) {
+                if (newDescriptors.getServiceDescriptors().isEmpty()) {
+                    // If no new service descriptors are available, log a warning.
+                    // Keep any previous service descriptors to provide some robustness for degraded operation.
+                    if (serviceDescriptors.get() == null) {
+                        log.warn("Discovery returned zero available service instances. No previous service " +
+                                "descriptors are available.");
+                    }
+                    else {
+                        log.warn("Discovery returned zero available service instances. Keeping previous set of instances.");
+                    }
+                }
+                else {
+                    // Update with the new descriptors.
                     serviceDescriptors.set(newDescriptors);
                     target.updateServiceDescriptors(newDescriptors.getServiceDescriptors());
                     delay = newDescriptors.getMaxAge();
                 }
-                // else current descriptors are not null (i.e. have previously been set), *and* new descriptors are empty;
-                // therefore do not replace.  a little bit of robustness for degraded operation.
+
                 errorBackOff.success();
 
                 if (delay == null) {

--- a/discovery/src/test/java/com/proofpoint/discovery/client/balancing/TestHttpServiceBalancerListenerAdapter.java
+++ b/discovery/src/test/java/com/proofpoint/discovery/client/balancing/TestHttpServiceBalancerListenerAdapter.java
@@ -32,9 +32,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -42,7 +40,9 @@ import java.util.concurrent.TimeUnit;
 
 import static com.proofpoint.concurrent.Threads.daemonThreadsNamed;
 import static com.proofpoint.testing.Assertions.assertEqualsIgnoreOrder;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -95,10 +95,7 @@ public class TestHttpServiceBalancerListenerAdapter
     {
         updater.start();
 
-        ArgumentCaptor<Multiset> captor = ArgumentCaptor.forClass(Multiset.class);
-        verify(httpServiceBalancer).updateHttpUris(captor.capture());
-
-        assertEquals(captor.getValue(), ImmutableMultiset.of());
+        verify(httpServiceBalancer, never()).updateHttpUris(any());
     }
 
     @Test


### PR DESCRIPTION
It can be unexpected that a discovered client keeps working when there are no service descriptions in discovery. Log a warning to indicate what is happening.