### PR TITLE
Reporting branch for Splunk Observability added

### DIFF
--- a/reporting-client/src/main/java/com/proofpoint/reporting/ForSplunkObservabilityClient.java
+++ b/reporting-client/src/main/java/com/proofpoint/reporting/ForSplunkObservabilityClient.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.proofpoint.reporting;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Qualifier
+@interface ForSplunkObservabilityClient
+{
+}

--- a/reporting-client/src/main/java/com/proofpoint/reporting/ReportingSplunkObservabilityModule.java
+++ b/reporting-client/src/main/java/com/proofpoint/reporting/ReportingSplunkObservabilityModule.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.proofpoint.reporting;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.proofpoint.configuration.AbstractConfigurationAwareModule;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.ThreadPoolExecutor.DiscardOldestPolicy;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static com.proofpoint.concurrent.Threads.daemonThreadsNamed;
+import static com.proofpoint.configuration.ConfigBinder.bindConfig;
+import static com.proofpoint.http.client.HttpClientBinder.httpClientBinder;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+
+public class ReportingSplunkObservabilityModule
+    extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        binder.bind(ReportScheduler.class).in(SINGLETON);
+        binder.bind(ReportCollector.class).in(SINGLETON);
+        binder.bind(ReportSink.class).to(SplunkObservabilityQueue.class).in(SINGLETON);
+        binder.bind(SplunkObservabilityClient.class).in(SINGLETON);
+
+        httpClientBinder(binder).bindBalancingHttpClient("splunk-observability", ForSplunkObservabilityClient.class);
+        bindConfig(binder).bind(SplunkObservabilityClientConfig.class);
+
+        binder.install(new ReportingBaseMetricsModule());
+    }
+
+    @Provides
+    @ForReportCollector
+    private static ScheduledExecutorService createCollectionExecutorService()
+    {
+        return newSingleThreadScheduledExecutor(daemonThreadsNamed("splunk-observability-reporting-collector-%s"));
+    }
+
+    @Provides
+    @ForSplunkObservabilityClient
+    private static ExecutorService createClientExecutorService()
+    {
+        return new ThreadPoolExecutor(1, 1, 0, TimeUnit.NANOSECONDS, new LinkedBlockingQueue<>(5),
+                        daemonThreadsNamed("splunk-observability-reporting-client-%s"),
+                        new DiscardOldestPolicy());
+    }
+}

--- a/reporting-client/src/main/java/com/proofpoint/reporting/SplunkObservabilityClient.java
+++ b/reporting-client/src/main/java/com/proofpoint/reporting/SplunkObservabilityClient.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2022 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.proofpoint.reporting;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
+import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.Table;
+import com.google.common.collect.Table.Cell;
+import com.proofpoint.http.client.BodySource;
+import com.proofpoint.http.client.DynamicBodySource;
+import com.proofpoint.http.client.HttpClient;
+import com.proofpoint.http.client.Request;
+import com.proofpoint.http.client.StringResponseHandler.StringResponse;
+import com.proofpoint.log.Logger;
+import com.proofpoint.node.NodeInfo;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import javax.inject.Inject;
+import java.io.BufferedOutputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Pattern;
+
+import static com.proofpoint.http.client.Request.Builder.preparePost;
+import static com.proofpoint.http.client.StringResponseHandler.createStringResponseHandler;
+import static java.util.Objects.requireNonNull;
+
+public class SplunkObservabilityClient
+{
+    private static final Logger logger = Logger.get(SplunkObservabilityClient.class);
+    private static final JsonFactory JSON_FACTORY = new JsonFactory();
+    private static final URI UPLOAD_DATAPOINTS_URI = URI.create("v2/datapoint");
+    private static final URI UPLOAD_EVENTS_URI = URI.create("v2/event");
+    private final String authToken;
+    private final Map<String, String> instanceTags;
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    SplunkObservabilityClient(NodeInfo nodeInfo, @ForSplunkObservabilityClient HttpClient httpClient, SplunkObservabilityClientConfig splunkObservabilityClientConfig,
+                              ReportTagConfig reportTagConfig, ObjectMapper objectMapper)
+    {
+        this.objectMapper = requireNonNull(objectMapper, "objectMapper is null");
+        requireNonNull(nodeInfo,"nodeInfo is null");
+        requireNonNull(splunkObservabilityClientConfig, "splunkObservabilityClientConfig is null");
+        this.authToken = splunkObservabilityClientConfig.getAuthToken();
+        requireNonNull(reportTagConfig, "reportTagConfig is null");
+
+        Builder<String, String> builder = ImmutableMap.builder();
+        builder.put("application", nodeInfo.getApplication());
+        if (splunkObservabilityClientConfig.isIncludeHostTag()) {
+            builder.put("host", nodeInfo.getInternalHostname());
+        }
+        builder.put("environment", nodeInfo.getEnvironment());
+        builder.put("pool", nodeInfo.getPool());
+        builder.putAll(reportTagConfig.getTags());
+        this.instanceTags = builder.build();
+
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+    }
+
+    public void report(long systemTimeMillis, Table<String, Map<String, String>, Object> collectedData)
+    {
+        //Reporting data points
+        reportEach(systemTimeMillis, collectedData.cellSet().stream()
+                .filter(cell -> cell.getValue() instanceof Number)
+                .collect(ImmutableTable.toImmutableTable(
+                        Table.Cell::getRowKey,
+                        Table.Cell::getColumnKey,
+                        Table.Cell::getValue
+                )), true);
+
+        //Reporting events
+        reportEach(systemTimeMillis, collectedData.cellSet().stream()
+                .filter(cell -> !(cell.getValue() instanceof Number))
+                .filter(cell -> cell.getValue() != "")
+                .collect(ImmutableTable.toImmutableTable(
+                        Table.Cell::getRowKey,
+                        Table.Cell::getColumnKey,
+                        Table.Cell::getValue
+                )), false);
+    }
+
+    private void reportEach(long systemTimeMillis, Table<String, Map<String, String>, Object> collectedData, boolean reportDatapoints)
+    {
+        if (collectedData.isEmpty()) {
+            return;
+        }
+        URI uploadUri;
+        BodySource jsonBodySource;
+        if (reportDatapoints) {
+            uploadUri = UPLOAD_DATAPOINTS_URI;
+            jsonBodySource = new DataPointJsonBodySource(systemTimeMillis, collectedData);
+        } else {
+            uploadUri = UPLOAD_EVENTS_URI;
+            jsonBodySource = new EventJsonBodySource(systemTimeMillis, collectedData);
+        }
+        Request request = preparePost()
+                .setUri(uploadUri)
+                .setHeader("Content-Type", "application/json")
+                .setHeader("X-SF-Token", this.authToken)
+                .setBodySource(jsonBodySource)
+                .build();
+        try {
+            StringResponse response = httpClient.execute(request, createStringResponseHandler());
+            if (response.getStatusCode() != 200) {
+                logger.warn("Failed to report stats: %s %s %s", response.getStatusCode(), response.getStatusMessage(), response.getBody());
+            }
+        } catch (RuntimeException e) {
+            logger.warn(e, "Exception when trying to report stats");
+        }
+    }
+
+    private static abstract class CollectedDataPoint
+    {
+        private static final Pattern NOT_ACCEPTED_CHARACTER_PATTERN_DIMENSION_NAME = Pattern.compile("[^-A-Za-z0-9_]");
+        private static final Pattern NOT_ALPHA_PREFIX_PATTERN = Pattern.compile("^[^A-Za-z]+[-A-Za-z0-9_]*");
+        private static final Pattern PROHIBITED_ALPHA_PREFIXES_PATTERN = Pattern.compile("^(sf_|aws_|gcp_|azure_)[-A-Za-z0-9_]*");
+        private static final Pattern CLEAN_DIMENSION_VALUE = Pattern.compile("[^-A-Za-z0-9./_]");
+        private static final String RULE_ENFORCEMENT_PREFIX = "z_";
+        private static final int MAX_DIMENSION_NAME_LENGTH = 128;
+        private static final int MAX_DIMENSION_VALUE_LENGTH = 256;
+        private static final String collectedNameToDimension = "Platform_Metric_Name";
+
+        @JsonProperty
+        private final long timestamp;
+        @JsonProperty
+        private final Map<String, String> dimensions;
+
+        @SuppressWarnings("ConstantConditions")
+        @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
+        CollectedDataPoint(long systemTimeMillis, Cell<String, Map<String, String>, Object> cell, Map<String, String> instanceTags, boolean isEvent)
+        {
+            timestamp = systemTimeMillis;
+            HashMap<String, String> dims = new HashMap<>(instanceTags);
+            for (Entry<String, String> entry : cell.getColumnKey().entrySet()) {
+                String dimensionName = enforceDimensionNameRules(entry.getKey());
+                String dimensionValue = CLEAN_DIMENSION_VALUE.matcher(entry.getValue()).replaceAll("_");
+                if (dimensionName.length() == 0 || dimensionValue.length() == 0) {
+                    logger.warn("Dropped empty dimension name: %s or value: %s", dimensionName, dimensionValue);
+                    continue;
+                }
+                putOrLogDroppedDuplicateDimension(dims, dimensionName, enforceLengthMaximum(dimensionValue, MAX_DIMENSION_VALUE_LENGTH));
+            }
+            if (isEvent) {
+                String dimensionValue = CLEAN_DIMENSION_VALUE.matcher(cell.getRowKey()).replaceAll("_");
+                putOrLogDroppedDuplicateDimension(dims, collectedNameToDimension, enforceLengthMaximum(dimensionValue, MAX_DIMENSION_VALUE_LENGTH));
+            }
+            dimensions = dims;
+        }
+
+        private String enforceLengthMaximum(String str, int maximum)
+        {
+            if (str.length() > maximum) {
+                str = str.substring(0,maximum);
+            }
+            return str;
+        }
+
+        private String enforceDimensionNameRules(String dimensionName)
+        {
+            dimensionName = NOT_ACCEPTED_CHARACTER_PATTERN_DIMENSION_NAME.matcher(dimensionName).replaceAll("_");
+            if (NOT_ALPHA_PREFIX_PATTERN.matcher(dimensionName).matches() || PROHIBITED_ALPHA_PREFIXES_PATTERN.matcher(dimensionName).matches()) {
+                dimensionName = RULE_ENFORCEMENT_PREFIX + dimensionName;
+            }
+            dimensionName = enforceLengthMaximum(dimensionName, MAX_DIMENSION_NAME_LENGTH);
+            return dimensionName;
+        }
+
+        private void putOrLogDroppedDuplicateDimension(Map<String,String> dimensions, String dimensionName, String dimensionValue)
+        {
+            if (dimensions.putIfAbsent(dimensionName, dimensionValue) != null) {
+                logger.warn("Dropped duplicate dimension name: %s, value %s", dimensionName, dimensionValue);
+            }
+        }
+    }
+
+    private static class DataPoint extends CollectedDataPoint
+    {
+        private static final Pattern NOT_ACCEPTED_CHARACTER_PATTERN_METRIC = Pattern.compile("[^-A-Za-z0-9./_]");
+        private static final int MAX_METRIC_LENGTH = 256;
+        @JsonProperty
+        private final String metric;
+        @JsonProperty
+        private final Object value;
+
+        @SuppressWarnings("ConstantConditions")
+        @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
+        DataPoint(long systemTimeMillis, Cell<String, Map<String, String>, Object> cell, Map<String, String> instanceTags)
+        {
+            super(systemTimeMillis, cell, instanceTags, false);
+            String metricName = NOT_ACCEPTED_CHARACTER_PATTERN_METRIC.matcher(cell.getRowKey()).replaceAll("_");
+            metric = super.enforceLengthMaximum(metricName,MAX_METRIC_LENGTH);
+            value = cell.getValue();
+        }
+    }
+
+    private static class Event extends CollectedDataPoint
+    {
+        private static final Pattern NOT_ACCEPTED_CHARACTER_PATTERN_EVENTTYPE = Pattern.compile("[^\\x21-\\x7E]");
+        private static final int MAX_EVENTTYPE_LENGTH = 256;
+        @JsonProperty
+        private static final String category = "USER_DEFINED";
+        @JsonProperty
+        private final String eventType;
+
+        @SuppressWarnings("ConstantConditions")
+        @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
+        Event(long systemTimeMillis, Cell<String, Map<String, String>, Object> cell, Map<String, String> instanceTags)
+        {
+            super(systemTimeMillis, cell, instanceTags, true);
+            String eventString = NOT_ACCEPTED_CHARACTER_PATTERN_EVENTTYPE.matcher((String) cell.getValue()).replaceAll("_");
+            eventString = super.enforceLengthMaximum(eventString, MAX_EVENTTYPE_LENGTH);
+            eventType = eventString;
+        }
+    }
+
+    private abstract class JsonBodySource implements DynamicBodySource
+    {
+        private final long systemTimeMillis;
+        private final Table<String, Map<String, String>, Object> collectedData;
+
+        JsonBodySource(long systemTimeMillis, Table<String, Map<String, String>, Object> collectedData)
+        {
+            this.systemTimeMillis = systemTimeMillis;
+            this.collectedData = collectedData;
+        }
+    }
+
+    private class DataPointJsonBodySource extends JsonBodySource
+    {
+        DataPointJsonBodySource(long systemTimeMillis, Table<String, Map<String, String>, Object> collectedData)
+        {
+            super(systemTimeMillis,collectedData);
+        }
+
+        @Override
+        public Writer start(final OutputStream out)
+            throws Exception
+        {
+            final BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(out);
+            final JsonGenerator generator = JSON_FACTORY.createGenerator(bufferedOutputStream, JsonEncoding.UTF8)
+                    .setCodec(objectMapper);
+            final Iterator<Cell<String, Map<String, String>, Object>> iterator = super.collectedData.cellSet().iterator();
+
+            generator.writeStartObject();
+            generator.writeArrayFieldStart("gauge");
+
+            return () -> {
+                if (iterator.hasNext()) {
+                    generator.writeObject(new DataPoint(super.systemTimeMillis, iterator.next(), instanceTags));
+                }
+                else {
+                    generator.writeEndArray();
+                    generator.writeEndObject();
+                    generator.flush();
+                    bufferedOutputStream.flush();
+                    out.close();
+                }
+            };
+        }
+    }
+
+    private class EventJsonBodySource extends JsonBodySource
+    {
+        EventJsonBodySource(long systemTimeMillis, Table<String, Map<String, String>, Object> collectedData)
+        {
+            super(systemTimeMillis,collectedData);
+        }
+
+        @Override
+        public Writer start(final OutputStream out)
+                throws Exception
+        {
+            final BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(out);
+            final JsonGenerator generator = JSON_FACTORY.createGenerator(bufferedOutputStream, JsonEncoding.UTF8)
+                    .setCodec(objectMapper);
+            final Iterator<Cell<String, Map<String, String>, Object>> iterator = super.collectedData.cellSet().iterator();
+
+            generator.writeStartArray();
+
+            return () -> {
+                if (iterator.hasNext()) {
+                    generator.writeObject(new Event(super.systemTimeMillis, iterator.next(), instanceTags));
+                }
+                else {
+                    generator.writeEndArray();
+                    generator.flush();
+                    bufferedOutputStream.flush();
+                    out.close();
+                }
+            };
+        }
+    }
+}

--- a/reporting-client/src/main/java/com/proofpoint/reporting/SplunkObservabilityClientConfig.java
+++ b/reporting-client/src/main/java/com/proofpoint/reporting/SplunkObservabilityClientConfig.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.proofpoint.reporting;
+
+import com.proofpoint.configuration.Config;
+import com.proofpoint.configuration.ConfigSecuritySensitive;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+public class SplunkObservabilityClientConfig
+{
+    private boolean enabled = true;
+    private boolean includeHostTag = true;
+    private String authToken;
+
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    @Config("splunk-observability.enabled")
+    public SplunkObservabilityClientConfig setEnabled(boolean enabled)
+    {
+        this.enabled = enabled;
+        return this;
+    }
+
+    public boolean isIncludeHostTag()
+    {
+        return includeHostTag;
+    }
+
+    @Config("splunk-observability.include-host-tag")
+    public SplunkObservabilityClientConfig setIncludeHostTag(boolean includeHostTag)
+    {
+        this.includeHostTag = includeHostTag;
+        return this;
+    }
+
+    @NotNull
+    @NotEmpty
+    public String getAuthToken()
+    {
+        return authToken;
+    }
+
+    @ConfigSecuritySensitive
+    @Config("splunk-observability.auth-token")
+    public SplunkObservabilityClientConfig setAuthToken(String authToken)
+    {
+        this.authToken = authToken;
+        return this;
+    }
+}

--- a/reporting-client/src/main/java/com/proofpoint/reporting/SplunkObservabilityQueue.java
+++ b/reporting-client/src/main/java/com/proofpoint/reporting/SplunkObservabilityQueue.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.proofpoint.reporting;
+
+import com.google.common.collect.Table;
+
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+
+import static java.util.Objects.requireNonNull;
+
+public class SplunkObservabilityQueue implements ReportSink
+{
+    private final boolean enabled;
+    private final ExecutorService clientExecutorService;
+    private final SplunkObservabilityClient splunkObservabilityClient;
+
+    @Inject
+    SplunkObservabilityQueue(SplunkObservabilityClientConfig splunkObservabilityClientConfig, @ForSplunkObservabilityClient ExecutorService clientExecutorService, SplunkObservabilityClient splunkObservabilityClient)
+    {
+        enabled = splunkObservabilityClientConfig.isEnabled();
+        this.clientExecutorService = requireNonNull(clientExecutorService, "clientExecutorService is null");
+        this.splunkObservabilityClient = splunkObservabilityClient;
+    }
+
+    @Override
+    public void report(long systemTimeMillis, Table<String, Map<String, String>, Object> collectedData)
+    {
+        if(!enabled) {
+            return;
+        }
+
+        clientExecutorService.submit(() -> splunkObservabilityClient.report(systemTimeMillis, collectedData));
+    }
+}

--- a/reporting-client/src/test/java/com/proofpoint/reporting/TestSplunkObservabilityClient.java
+++ b/reporting-client/src/test/java/com/proofpoint/reporting/TestSplunkObservabilityClient.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2022 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.proofpoint.reporting;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Table;
+import com.proofpoint.http.client.HttpClient;
+import com.proofpoint.http.client.HttpStatus;
+import com.proofpoint.http.client.Request;
+import com.proofpoint.http.client.Response;
+import com.proofpoint.http.client.testing.TestingHttpClient;
+import com.proofpoint.http.client.testing.TestingHttpClient.Processor;
+import com.proofpoint.json.ObjectMapperProvider;
+import com.proofpoint.node.NodeConfig;
+import com.proofpoint.node.NodeInfo;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static com.proofpoint.http.client.testing.BodySourceTester.writeBodySourceTo;
+import static com.proofpoint.http.client.testing.TestingResponse.mockResponse;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class TestSplunkObservabilityClient
+{
+    private static final int TEST_TIME = 1234567890;
+    private NodeInfo nodeInfo;
+    private Table<String, Map<String, String>, Object> collectedData;
+    private HttpClient httpClientDatapoint;
+    private HttpClient httpClientEvent;
+    private HashMap<String, List<Map<String, Object>>> sentDataPointsJson;
+    private List<Map<String, Object>> sentEventsJson;
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+
+    @BeforeMethod
+    public void setup()
+    {
+        nodeInfo = new NodeInfo("test-application", new NodeConfig()
+                .setEnvironment("test_environment")
+                .setNodeInternalHostname("test.hostname")
+                .setPool("test_pool")
+        );
+
+        collectedData = HashBasedTable.create();
+        collectedData.put("Foo.Size", ImmutableMap.of(), 1.1);
+        collectedData.put("Foo.Ba:r.Size", ImmutableMap.of("dimension1","B\\a\"z"), 1.2);
+
+        httpClientDatapoint = new TestingHttpClient(new TestingDatapointResponseFunction());
+        httpClientEvent = new TestingHttpClient(new TestingEventResponseFunction());
+        sentDataPointsJson = null;
+        sentEventsJson = null;
+    }
+
+    @Test
+    public void testReportingDisabled()
+    {
+        httpClientDatapoint = new TestingHttpClient();
+        SplunkObservabilityClient client = new SplunkObservabilityClient(nodeInfo, httpClientDatapoint,
+                new SplunkObservabilityClientConfig().setEnabled(false).setAuthToken("test"), new ReportTagConfig(), objectMapper);
+        client.report(System.currentTimeMillis(), collectedData);
+    }
+
+    @Test
+    public void testReportDataPoints()
+    {
+        SplunkObservabilityClient client = new SplunkObservabilityClient(nodeInfo, httpClientDatapoint,
+                new SplunkObservabilityClientConfig().setAuthToken("test"), new ReportTagConfig(), objectMapper);
+        client.report(TEST_TIME, collectedData);
+        assertEquals(sentDataPointsJson.get("gauge").size(), 2);
+
+        for (Map<String, Object> map : sentDataPointsJson.get("gauge")) {
+            assertEquals(map.keySet(), Set.of("metric", "timestamp", "value", "dimensions"));
+            assertEquals(map.get("timestamp"), TEST_TIME);
+            Map<String, String> tags = (Map<String, String>) map.get("dimensions");
+            assertEquals(tags.get("application"), "test-application");
+            assertEquals(tags.get("host"), "test.hostname");
+            assertEquals(tags.get("environment"), "test_environment");
+            assertEquals(tags.get("pool"), "test_pool");
+        }
+        assertEquals(sentDataPointsJson.get("gauge").get(0).get("metric"), "Foo.Ba_r.Size");
+        assertEquals(sentDataPointsJson.get("gauge").get(1).get("metric"), "Foo.Size");
+        assertEquals(sentDataPointsJson.get("gauge").get(0).get("value"), 1.2);
+        assertEquals(sentDataPointsJson.get("gauge").get(1).get("value"), 1.1);
+        Map<String, String> dimensions = (Map<String, String>) sentDataPointsJson.get("gauge").get(0).get("dimensions");
+        assertEquals(dimensions.keySet(), Set.of("application", "host", "environment", "pool", "dimension1"));
+        assertEquals(dimensions.get("dimension1"), "B_a_z"); // "B\\a\"z");
+        dimensions = (Map<String, String>) sentDataPointsJson.get("gauge").get(1).get("dimensions");
+        assertEquals(dimensions.keySet(), Set.of("application", "host", "environment", "pool"));
+    }
+
+    @Test
+    public void testBadDimensions()
+    {
+        SplunkObservabilityClient client = new SplunkObservabilityClient(nodeInfo, httpClientDatapoint,
+                new SplunkObservabilityClientConfig().setAuthToken("test"), new ReportTagConfig(), objectMapper);
+        collectedData = HashBasedTable.create();
+        collectedData.put("Foo\\_8-_.bar", ImmutableMap.of("8di/.me_ns-ion2","B:a_d-i.s=h",
+                "sf_","dim/en._si#*on-v!alu8e",
+                "gcp_9dke", "test3",
+                "ab97_sf_aws_gcp_azure_10_ak","test4"), 6);
+        client.report(TEST_TIME, collectedData);
+        assertEquals(sentDataPointsJson.get("gauge").size(), 1);
+
+        assertEquals(sentDataPointsJson.get("gauge").get(0).get("metric"),"Foo__8-_.bar");
+        assertEquals(sentDataPointsJson.get("gauge").get(0).get("value"), 6);
+        Map<String, String> dimensions = (Map<String, String>) sentDataPointsJson.get("gauge").get(0).get("dimensions");
+        assertEquals(dimensions.keySet(), Set.of("application", "host", "environment", "pool", "z_8di__me_ns-ion2", "z_sf_","z_gcp_9dke","ab97_sf_aws_gcp_azure_10_ak"));
+        assertEquals(dimensions.get("z_8di__me_ns-ion2"), "B_a_d-i.s_h");
+        assertEquals(dimensions.get("z_sf_"), "dim/en._si__on-v_alu8e");
+        assertEquals(dimensions.get("z_gcp_9dke"), "test3");
+        assertEquals(dimensions.get("ab97_sf_aws_gcp_azure_10_ak"), "test4");
+    }
+
+    @Test
+    public void testEmptyDimensions()
+    {
+        SplunkObservabilityClient client = new SplunkObservabilityClient(nodeInfo, httpClientDatapoint,
+                new SplunkObservabilityClientConfig().setAuthToken("test"), new ReportTagConfig(), objectMapper);
+        collectedData = HashBasedTable.create();
+        collectedData.put("Foo.String", ImmutableMap.of("afds",""), 2);
+        collectedData.put("Foo.String2", ImmutableMap.of("","dfa"), 3);
+        client.report(TEST_TIME, collectedData);
+        assertEquals(sentDataPointsJson.get("gauge").size(), 2);
+        Map<String, String> dimensions = (Map<String, String>) sentDataPointsJson.get("gauge").get(0).get("dimensions");
+        assertEquals(dimensions.keySet(), Set.of("application", "host", "environment", "pool"));
+        dimensions = (Map<String, String>) sentDataPointsJson.get("gauge").get(1).get("dimensions");
+        assertEquals(dimensions.keySet(), Set.of("application", "host", "environment", "pool"));
+    }
+
+    @Test
+    public void testDuplicateDimensions()
+    {
+        SplunkObservabilityClient client = new SplunkObservabilityClient(nodeInfo, httpClientDatapoint,
+                new SplunkObservabilityClientConfig().setAuthToken("test"), new ReportTagConfig(), objectMapper);
+        collectedData = HashBasedTable.create();
+        collectedData.put("Foo.String", ImmutableMap.of("test_name","value_1",
+                "test&name", "value_2"), 2);
+        client.report(TEST_TIME, collectedData);
+        assertEquals(sentDataPointsJson.get("gauge").size(), 1);
+        Map<String, String> dimensions = (Map<String, String>) sentDataPointsJson.get("gauge").get(0).get("dimensions");
+        assertEquals(dimensions.keySet(), Set.of("application", "host", "environment", "pool", "test_name"));
+        assertEquals(dimensions.get("test_name"), "value_1");
+    }
+
+    @Test
+    public void testReportEvents()
+    {
+        SplunkObservabilityClient client = new SplunkObservabilityClient(nodeInfo, httpClientEvent,
+                new SplunkObservabilityClientConfig().setAuthToken("test"), new ReportTagConfig(), objectMapper);
+        collectedData = HashBasedTable.create();
+        collectedData.put("Foo.String", ImmutableMap.of(), "test value");
+        client.report(TEST_TIME, collectedData);
+        assertEquals(sentEventsJson, List.of(
+                ImmutableMap.of(
+                        "timestamp", TEST_TIME,
+                        "dimensions", ImmutableMap.of(
+                                "application", "test-application",
+                                "host", "test.hostname",
+                                "environment", "test_environment",
+                                "pool", "test_pool",
+                                "Platform_Metric_Name","Foo.String"
+                        ),
+                        "eventType", "test_value"
+                )
+        ));
+    }
+
+    @Test
+    public void testEmptyEventType()
+    {
+        SplunkObservabilityClient client = new SplunkObservabilityClient(nodeInfo, httpClientEvent,
+                new SplunkObservabilityClientConfig().setAuthToken("test"), new ReportTagConfig(), objectMapper);
+        collectedData = HashBasedTable.create();
+        collectedData.put("Foo.String", ImmutableMap.of(), "");
+        client.report(TEST_TIME, collectedData);
+        assertNull(sentEventsJson);
+    }
+
+    @Test
+    public void testConfiguredTags()
+    {
+        SplunkObservabilityClient client = new SplunkObservabilityClient(nodeInfo, httpClientDatapoint,
+                new SplunkObservabilityClientConfig().setAuthToken("test"), new ReportTagConfig()
+                        .setTags(ImmutableMap.of("foo", "ba:r", "baz", "quux")), objectMapper);
+        client.report(TEST_TIME, collectedData);
+        assertEquals(sentDataPointsJson.get("gauge").size(),2);
+
+        for (Map<String, Object> map : sentDataPointsJson.get("gauge")) {
+            assertEquals(map.keySet(), Set.of("metric", "timestamp", "value", "dimensions"));
+            Map<String, String> dimensions = (Map<String, String>) map.get("dimensions");
+            assertEquals(dimensions.get("foo"), "ba:r");
+            assertEquals(dimensions.get("baz"), "quux");
+        }
+        Map<String, String> dimensions = (Map<String, String>) sentDataPointsJson.get("gauge").get(0).get("dimensions");
+        assertEquals(dimensions.keySet(), Set.of("application", "host", "environment", "pool", "foo", "baz", "dimension1"));
+        dimensions = (Map<String, String>) sentDataPointsJson.get("gauge").get(1).get("dimensions");
+        assertEquals(dimensions.keySet(), Set.of("application", "host", "environment", "pool", "foo", "baz"));
+    }
+
+    @Test
+    public void testNoReportHost()
+    {
+        SplunkObservabilityClient client = new SplunkObservabilityClient(nodeInfo, httpClientDatapoint,
+                new SplunkObservabilityClientConfig().setAuthToken("test").setIncludeHostTag(false), new ReportTagConfig()
+                .setTags(ImmutableMap.of("foo", "ba:r", "baz", "quux")), objectMapper);
+        client.report(TEST_TIME, collectedData);
+        assertEquals(sentDataPointsJson.get("gauge").size(),2);
+
+        for (Map<String, Object> map : sentDataPointsJson.get("gauge")) {
+            assertEquals(map.keySet(), Set.of("metric", "timestamp", "value", "dimensions"));
+            Map<String, String> dimensions = (Map<String, String>) map.get("dimensions");
+            assertEquals(dimensions.get("foo"), "ba:r");
+            assertEquals(dimensions.get("baz"), "quux");
+        }
+        Map<String, String> dimensions = (Map<String, String>) sentDataPointsJson.get("gauge").get(0).get("dimensions");
+        assertEquals(dimensions.keySet(), Set.of("application", "environment", "pool", "foo", "baz", "dimension1"));
+        dimensions = (Map<String, String>) sentDataPointsJson.get("gauge").get(1).get("dimensions");
+        assertEquals(dimensions.keySet(), Set.of("application", "environment", "pool", "foo", "baz"));
+    }
+
+    private class TestingDatapointResponseFunction
+        implements Processor
+    {
+        @Override
+        public Response handle(Request input)
+        {
+            assertNull(sentDataPointsJson);
+            assertEquals(input.getMethod(), "POST");
+            assertEquals(input.getUri().toString(), "v2/datapoint");
+            assertEquals(input.getHeader("Content-Type"), "application/json");
+
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            try {
+                writeBodySourceTo(input.getBodySource(), outputStream);
+                BufferedInputStream inputStream = new BufferedInputStream(new ByteArrayInputStream(outputStream.toByteArray()));
+
+                sentDataPointsJson = new ObjectMapper().readValue(inputStream, new TypeReference<HashMap<String,List<Map<String, Object>>>>()
+                {
+                });
+                sentDataPointsJson = new HashMap<>(sentDataPointsJson);
+                sentDataPointsJson.get("gauge").sort(Comparator.comparing(o -> ((String) o.get("metric"))));
+
+            } catch (Exception e) {
+                throwIfUnchecked(e);
+                throw new RuntimeException(e);
+            }
+
+            return mockResponse(HttpStatus.OK);
+        }
+    }
+
+    private class TestingEventResponseFunction
+            implements Processor
+    {
+        @Override
+        public Response handle(Request input)
+        {
+            assertNull(sentEventsJson);
+            assertEquals(input.getMethod(), "POST");
+            assertEquals(input.getUri().toString(), "v2/event");
+            assertEquals(input.getHeader("Content-Type"), "application/json");
+
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            try {
+                writeBodySourceTo(input.getBodySource(), outputStream);
+                BufferedInputStream inputStream = new BufferedInputStream(new ByteArrayInputStream(outputStream.toByteArray()));
+
+                sentEventsJson = new ObjectMapper().readValue(inputStream, new TypeReference<List<Map<String, Object>>>()
+                {
+                });
+                sentEventsJson = Lists.newArrayList(sentEventsJson);
+                sentEventsJson.sort(Comparator.comparing(o -> ((String) o.get("eventType"))));
+
+            } catch (Exception e) {
+                throwIfUnchecked(e);
+                throw new RuntimeException(e);
+            }
+
+            return mockResponse(HttpStatus.OK);
+        }
+    }
+}

--- a/reporting-client/src/test/java/com/proofpoint/reporting/TestSplunkObservabilityClientConfig.java
+++ b/reporting-client/src/test/java/com/proofpoint/reporting/TestSplunkObservabilityClientConfig.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.proofpoint.reporting;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.proofpoint.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.proofpoint.configuration.testing.ConfigAssertions.assertLegacyEquivalence;
+import static com.proofpoint.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.proofpoint.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestSplunkObservabilityClientConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(SplunkObservabilityClientConfig.class)
+                .setEnabled(true)
+                .setIncludeHostTag(true)
+                .setAuthToken(null)
+        );
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("splunk-observability.enabled", "false")
+                .put("splunk-observability.include-host-tag", "false")
+                .put("splunk-observability.auth-token","test1-token")
+                .build();
+
+        SplunkObservabilityClientConfig expected = new SplunkObservabilityClientConfig()
+                .setEnabled(false)
+                .setIncludeHostTag(false)
+                .setAuthToken("test1-token");
+
+        assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testLegacyProperties()
+    {
+        assertLegacyEquivalence(SplunkObservabilityClientConfig.class,
+                ImmutableMap.of("splunk-observability.auth-token", "test1-token"));
+    }
+}


### PR DESCRIPTION
This includes reporting for datapoints and events to Splunk Observability with little to no changes required by currrent platform users. This new branch is heavily patterned after the current reporting-client branch to facilitate that easy switch over for users. Currently gathered data is forrmatted to Splunk JSON and reported there. A splunk observability realm/url and auth token will need to be provided to write to splunk.