### PR TITLE
Added getServer to HttpServer

### DIFF
--- a/http-server/src/main/java/com/proofpoint/http/server/HttpServer.java
+++ b/http-server/src/main/java/com/proofpoint/http/server/HttpServer.java
@@ -503,6 +503,11 @@ public class HttpServer
         return busyThreads;
     }
 
+    public Server getServer()
+    {
+        return server;
+    }
+
     private static Set<X509Certificate> loadAllX509Certificates(HttpServerConfig config)
     {
         ImmutableSet.Builder<X509Certificate> certificates = ImmutableSet.builder();

--- a/http-server/src/test/java/com/proofpoint/http/server/testing/TestTestingHttpServer.java
+++ b/http-server/src/test/java/com/proofpoint/http/server/testing/TestTestingHttpServer.java
@@ -69,6 +69,7 @@ import static com.proofpoint.testing.Assertions.assertGreaterThan;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertNotNull;
 
 public class TestTestingHttpServer
 {
@@ -254,6 +255,14 @@ public class TestTestingHttpServer
         finally {
             lifeCycleManager.stop();
         }
+    }
+
+    @Test
+    public void testGetServer()
+            throws Exception
+    {
+        TestingHttpServer httpServer = createTestingHttpServer(new DummyServlet(), Map.of());
+        assertNotNull(httpServer.getServer());
     }
 
     private static void assertResource(URI baseUri, HttpClient client, String path, String contents)


### PR DESCRIPTION
This allows access to the underlining Jetty Server.  
This can be used for stuff like adding a SessionHandler.
eg
```java
public addSessionHandler(HttpServer httpServer, SessionHandler sessionHandler){
         Server jettyServer = httpServer.getServer();
         ServletContextHandler. context = findCorrectContextHandler(jettyServer);
         context.setSessionHandler(sessionHandler);     
}
```


