### PR TITLE
Upgrade base image to 2.66

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+Platform 2.84
+
+* Library Upgrades
+
+  - Base Docker image to c15-java11:2.72 (was 2.67)
+
 Platform 2.83
 
 * Docker images now include any values of the GIT_COMMIT, BUILD_URL, or GIT_URL

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -39,7 +39,7 @@
         <project.rpm.username>${project.artifactId}</project.rpm.username>
         <project.docker.project>dev-docker-local</project.docker.project>
         <project.docker.name>%a</project.docker.name>
-        <project.docker.from>repocache.nonprod.ppops.net/dev-docker-local/c15-java11:2.67</project.docker.from>
+        <project.docker.from>repocache.nonprod.ppops.net/dev-docker-local/c15-java11:2.72</project.docker.from>
         <project.docker.uid>1000</project.docker.uid>
         <project.docker.verbose>false</project.docker.verbose>
 


### PR DESCRIPTION
New base image includes updates to openjdk-11-jdk-headless and openjdk-11-jre-headless (from 11.0.16 to 11.0.18)