### PR TITLE
Updated modernizer to support java 17 and maven 3.9

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -94,7 +94,7 @@
         <dep.jersey.version>2.27</dep.jersey.version>
         <dep.jmh.version>1.35</dep.jmh.version>
         <dep.jacoco.version>0.8.5</dep.jacoco.version>
-        <dep.modernizer.version>2.2.0</dep.modernizer.version>
+        <dep.modernizer.version>2.5.0</dep.modernizer.version>
 
         <platform.jacoco.merged-data-file>${project.build.directory}/merged.exec</platform.jacoco.merged-data-file>
     </properties>


### PR DESCRIPTION
Updated modernizer 
This is because on java 17 we get the following error
```Execution modernizer of goal org.gaul:modernizer-maven-plugin:2.2.0:modernizer failed: Unsupported class file major version 61```

And on maven 3.9 we get the following error
```Execution modernizer of goal org.gaul:modernizer-maven-plugin:2.4.0:modernizer failed: A required class was missing while executing org.gaul:modernizer-maven-plugin:2.4.0:modernizer: org/codehaus/plexus/util/StringUtils```