### PR TITLE
Upgrade modernizer and jacoco to support Java 17

### DIFF
--- a/concurrent/src/main/java/com/proofpoint/concurrent/MoreFutures.java
+++ b/concurrent/src/main/java/com/proofpoint/concurrent/MoreFutures.java
@@ -1,5 +1,6 @@
 package com.proofpoint.concurrent;
 
+import com.google.common.collect.Streams;
 import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.FluentFuture;
 import com.google.common.util.concurrent.FutureCallback;
@@ -274,7 +275,7 @@ public final class MoreFutures
     {
 
         requireNonNull(futures, "futures is null");
-        checkArgument(!isEmpty(futures), "futures is empty");
+        checkArgument(Streams.stream(futures).findAny().isPresent(), "futures is empty");
 
         ExtendedSettableFuture<V> firstCompletedFuture = ExtendedSettableFuture.create();
         for (ListenableFuture<? extends V> future : futures) {
@@ -295,7 +296,7 @@ public final class MoreFutures
     public static <V> ListenableFuture<V> whenAnyCompleteCancelOthers(Iterable<? extends ListenableFuture<? extends V>> futures)
     {
         requireNonNull(futures, "futures is null");
-        checkArgument(!isEmpty(futures), "futures is empty");
+        checkArgument(Streams.stream(futures).findAny().isPresent(), "futures is empty");
 
         // wait for the first task to unblock and then cancel all futures to free up resources
         ListenableFuture<V> anyComplete = whenAnyComplete(futures);
@@ -327,7 +328,7 @@ public final class MoreFutures
     public static <V> CompletableFuture<V> firstCompletedFuture(Iterable<? extends CompletionStage<? extends V>> futures, boolean propagateCancel)
     {
         requireNonNull(futures, "futures is null");
-        checkArgument(!isEmpty(futures), "futures is empty");
+        checkArgument(Streams.stream(futures).findAny().isPresent(), "futures is empty");
 
         CompletableFuture<V> future = new CompletableFuture<>();
         for (CompletionStage<? extends V> stage : futures) {

--- a/concurrent/src/main/java/com/proofpoint/concurrent/MoreFutures.java
+++ b/concurrent/src/main/java/com/proofpoint/concurrent/MoreFutures.java
@@ -272,6 +272,7 @@ public final class MoreFutures
      */
     public static <V> ListenableFuture<V> whenAnyComplete(Iterable<? extends ListenableFuture<? extends V>> futures)
     {
+
         requireNonNull(futures, "futures is null");
         checkArgument(!isEmpty(futures), "futures is empty");
 

--- a/discovery/src/main/java/com/proofpoint/discovery/client/testing/StaticServiceSelector.java
+++ b/discovery/src/main/java/com/proofpoint/discovery/client/testing/StaticServiceSelector.java
@@ -17,10 +17,10 @@ package com.proofpoint.discovery.client.testing;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import com.proofpoint.discovery.client.ServiceDescriptor;
 import com.proofpoint.discovery.client.ServiceSelector;
 
+import java.util.Collection;
 import java.util.List;
 
 import static com.proofpoint.discovery.client.ServiceSelectorConfig.DEFAULT_POOL;
@@ -37,11 +37,11 @@ public class StaticServiceSelector implements ServiceSelector
         this(ImmutableList.copyOf(serviceDescriptors));
     }
 
-    public StaticServiceSelector(Iterable<ServiceDescriptor> serviceDescriptors)
+    public StaticServiceSelector(Collection<ServiceDescriptor> serviceDescriptors)
     {
         requireNonNull(serviceDescriptors, "serviceDescriptors is null");
 
-        ServiceDescriptor serviceDescriptor = Iterables.getFirst(serviceDescriptors, null);
+        ServiceDescriptor serviceDescriptor = serviceDescriptors.stream().findFirst().orElse(null);
         if (serviceDescriptor != null) {
             this.type = serviceDescriptor.getType();
             this.pool = serviceDescriptor.getPool();

--- a/discovery/src/main/java/com/proofpoint/discovery/client/testing/StaticServiceSelector.java
+++ b/discovery/src/main/java/com/proofpoint/discovery/client/testing/StaticServiceSelector.java
@@ -17,10 +17,10 @@ package com.proofpoint.discovery.client.testing;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
 import com.proofpoint.discovery.client.ServiceDescriptor;
 import com.proofpoint.discovery.client.ServiceSelector;
 
-import java.util.Collection;
 import java.util.List;
 
 import static com.proofpoint.discovery.client.ServiceSelectorConfig.DEFAULT_POOL;
@@ -37,11 +37,11 @@ public class StaticServiceSelector implements ServiceSelector
         this(ImmutableList.copyOf(serviceDescriptors));
     }
 
-    public StaticServiceSelector(Collection<ServiceDescriptor> serviceDescriptors)
+    public StaticServiceSelector(Iterable<ServiceDescriptor> serviceDescriptors)
     {
         requireNonNull(serviceDescriptors, "serviceDescriptors is null");
 
-        ServiceDescriptor serviceDescriptor = serviceDescriptors.stream().findFirst().orElse(null);
+        ServiceDescriptor serviceDescriptor = Streams.stream(serviceDescriptors).findFirst().orElse(null);
         if (serviceDescriptor != null) {
             this.type = serviceDescriptor.getType();
             this.pool = serviceDescriptor.getPool();

--- a/discovery/src/test/java/com/proofpoint/discovery/client/TestHttpAnnouncementBinder.java
+++ b/discovery/src/test/java/com/proofpoint/discovery/client/TestHttpAnnouncementBinder.java
@@ -15,7 +15,7 @@
  */
 package com.proofpoint.discovery.client;
 
-import com.google.common.collect.Iterables;
+import com.google.common.collect.MoreCollectors;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
@@ -195,7 +195,7 @@ public class TestHttpAnnouncementBinder
     {
         assertNotNull(actualAnnouncements);
         assertEquals(actualAnnouncements.size(), 1);
-        ServiceAnnouncement announcement = Iterables.getOnlyElement(actualAnnouncements);
+        ServiceAnnouncement announcement = actualAnnouncements.stream().collect(MoreCollectors.onlyElement());
         assertEquals(announcement.getType(), expected.getType());
         assertEquals(announcement.getProperties(), expected.getProperties());
     }

--- a/discovery/src/test/java/com/proofpoint/discovery/client/TestHttpServiceSelectorBinder.java
+++ b/discovery/src/test/java/com/proofpoint/discovery/client/TestHttpServiceSelectorBinder.java
@@ -16,6 +16,7 @@
 package com.proofpoint.discovery.client;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.MoreCollectors;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Key;
@@ -33,7 +34,6 @@ import java.net.URI;
 import java.util.List;
 import java.util.Set;
 
-import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.proofpoint.discovery.client.DiscoveryBinder.discoveryBinder;
 import static com.proofpoint.discovery.client.ServiceTypes.serviceType;
 import static com.proofpoint.discovery.client.announce.ServiceAnnouncement.serviceAnnouncement;
@@ -67,9 +67,10 @@ public class TestHttpServiceSelectorBinder
         discoveryClient.announce(Set.of(serviceAnnouncement("apple").addProperty("http", "fake://server-http").build()));
 
         HttpServiceSelector selector = injector.getInstance(Key.get(HttpServiceSelector.class, com.proofpoint.http.client.ServiceTypes.serviceType("apple")));
-        assertEquals(getOnlyElement(selector.selectHttpService()), URI.create("fake://server-http"));
+
+        assertEquals(selector.selectHttpService().stream().collect(MoreCollectors.onlyElement()), URI.create("fake://server-http"));
         HttpServiceSelector legacySelector = injector.getInstance(Key.get(HttpServiceSelector.class, serviceType("apple")));
-        assertEquals(getOnlyElement(legacySelector.selectHttpService()), URI.create("fake://server-http"));
+        assertEquals(legacySelector.selectHttpService().stream().collect(MoreCollectors.onlyElement()), URI.create("fake://server-http"));
     }
 
     @Test
@@ -90,7 +91,7 @@ public class TestHttpServiceSelectorBinder
         discoveryClient.announce(Set.of(serviceAnnouncement("apple").addProperty("http", "fake://server-http").build()));
 
         HttpServiceSelector selector = injector.getInstance(Key.get(HttpServiceSelector.class, com.proofpoint.http.client.ServiceTypes.serviceType("apple")));
-        assertEquals(getOnlyElement(selector.selectHttpService()), URI.create("fake://server-http"));
+        assertEquals(selector.selectHttpService().stream().collect(MoreCollectors.onlyElement()), URI.create("fake://server-http"));
     }
 
     @Test
@@ -100,9 +101,9 @@ public class TestHttpServiceSelectorBinder
         discoveryClient.announce(Set.of(serviceAnnouncement("apple").addProperty("https", "fake://server-https").build()));
 
         HttpServiceSelector selector = injector.getInstance(Key.get(HttpServiceSelector.class, com.proofpoint.http.client.ServiceTypes.serviceType("apple")));
-        assertEquals(getOnlyElement(selector.selectHttpService()), URI.create("fake://server-https"));
+        assertEquals(selector.selectHttpService().stream().collect(MoreCollectors.onlyElement()), URI.create("fake://server-https"));
         HttpServiceSelector legacySelector = injector.getInstance(Key.get(HttpServiceSelector.class, serviceType("apple")));
-        assertEquals(getOnlyElement(legacySelector.selectHttpService()), URI.create("fake://server-https"));
+        assertEquals(legacySelector.selectHttpService().stream().collect(MoreCollectors.onlyElement()), URI.create("fake://server-https"));
     }
 
     @Test

--- a/discovery/src/test/java/com/proofpoint/discovery/client/TestServiceInventory.java
+++ b/discovery/src/test/java/com/proofpoint/discovery/client/TestServiceInventory.java
@@ -17,6 +17,7 @@ package com.proofpoint.discovery.client;
 
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.MoreCollectors;
 import com.google.common.collect.Multiset;
 import com.google.common.io.Resources;
 import com.proofpoint.http.client.balancing.HttpServiceBalancerImpl;
@@ -87,7 +88,7 @@ public class TestServiceInventory
         verify(balancer).updateHttpUris(uriMultisetCaptor.capture());
         assertEquals(Iterables.size(uriMultisetCaptor.getValue()), 1);
 
-        URI uri = Iterables.getOnlyElement(uriMultisetCaptor.getValue());
+        URI uri = uriMultisetCaptor.getValue().stream().collect(MoreCollectors.onlyElement());
         assertEquals(uri, URI.create("https://example.com:4111"));
 
         assertEquals(Iterables.size(serviceInventory.getServiceDescriptors()), 0);

--- a/discovery/src/test/java/com/proofpoint/discovery/client/announce/TestAnnouncement.java
+++ b/discovery/src/test/java/com/proofpoint/discovery/client/announce/TestAnnouncement.java
@@ -15,7 +15,7 @@
  */
 package com.proofpoint.discovery.client.announce;
 
-import com.google.common.collect.Iterables;
+import com.google.common.collect.MoreCollectors;
 import com.google.common.io.Resources;
 import com.proofpoint.json.JsonCodec;
 import org.testng.annotations.Test;
@@ -55,7 +55,7 @@ public class TestAnnouncement
 
         // set id in expected
         List<Map<String, Object>> services = toServices(expected.get("services"));
-        services.get(0).put("id", Iterables.getOnlyElement(announcement.getServices()).getId().toString());
+        services.get(0).put("id", announcement.getServices().stream().collect(MoreCollectors.onlyElement()).getId().toString());
 
         assertEquals(actual, expected);
     }

--- a/event/src/main/java/com/proofpoint/event/client/EventTypeMetadata.java
+++ b/event/src/main/java/com/proofpoint/event/client/EventTypeMetadata.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
-import static com.google.common.collect.Iterables.getFirst;
 import static com.proofpoint.configuration.TypeParameterUtils.getTypeParameters;
 import static com.proofpoint.event.client.AnnotationUtils.findAnnotatedMethods;
 import static com.proofpoint.event.client.EventDataType.getEventDataType;
@@ -196,10 +195,10 @@ final class EventTypeMetadata<T>
             }
         }
 
-        this.uuidField = getFirst(specialFields.get(EventFieldMapping.UUID), null);
-        this.timestampField = getFirst(specialFields.get(EventFieldMapping.TIMESTAMP), null);
-        this.hostField = getFirst(specialFields.get(EventFieldMapping.HOST), null);
-        this.traceTokenField = getFirst(specialFields.get(EventFieldMapping.TRACE_TOKEN), null);
+        this.uuidField = specialFields.get(EventFieldMapping.UUID).stream().findFirst().orElse(null);
+        this.timestampField = specialFields.get(EventFieldMapping.TIMESTAMP).stream().findFirst().orElse(null);
+        this.hostField = specialFields.get(EventFieldMapping.HOST).stream().findFirst().orElse(null);
+        this.traceTokenField = specialFields.get(EventFieldMapping.TRACE_TOKEN).stream().findFirst().orElse(null);
 
         this.fields = Ordering.from(EventFieldMetadata.NAME_COMPARATOR).immutableSortedCopy(fields.values());
 

--- a/http-client/src/main/java/com/proofpoint/http/client/HttpUriBuilder.java
+++ b/http-client/src/main/java/com/proofpoint/http/client/HttpUriBuilder.java
@@ -2,9 +2,9 @@ package com.proofpoint.http.client;
 
 import com.google.common.base.Ascii;
 import com.google.common.base.Splitter;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Streams;
 import com.google.common.net.HostAndPort;
 import com.google.common.primitives.Bytes;
 
@@ -176,7 +176,7 @@ public class HttpUriBuilder
     {
         requireNonNull(name, "name is null");
 
-        if (Iterables.isEmpty(values)) {
+        if (Streams.stream(values).findAny().isEmpty()) {
             params.put(name, null);
         }
 

--- a/jaxrs/src/main/java/com/proofpoint/jaxrs/testing/GuavaMultivaluedMap.java
+++ b/jaxrs/src/main/java/com/proofpoint/jaxrs/testing/GuavaMultivaluedMap.java
@@ -3,7 +3,6 @@ package com.proofpoint.jaxrs.testing;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ForwardingMap;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
@@ -62,7 +61,7 @@ public class GuavaMultivaluedMap<K, V>
     @Override
     public V getFirst(K key)
     {
-        return Iterables.getFirst(multimap.get(key), null);
+        return multimap.get(key).stream().findFirst().orElse(null);
     }
 
     @Override

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -94,7 +94,7 @@
         <dep.jersey.version>2.27</dep.jersey.version>
         <dep.jmh.version>1.35</dep.jmh.version>
         <dep.jacoco.version>0.8.5</dep.jacoco.version>
-        <dep.modernizer.version>2.2.0</dep.modernizer.version>
+        <dep.modernizer.version>2.5.0</dep.modernizer.version>
 
         <platform.jacoco.merged-data-file>${project.build.directory}/merged.exec</platform.jacoco.merged-data-file>
     </properties>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -546,7 +546,6 @@
                             <exclusionPattern>com/google/common/collect/ImmutableMap.copyOf:.*</exclusionPattern>
                             <exclusionPattern>com/google/common/collect/ImmutableSet.of:.*</exclusionPattern>
                             <exclusionPattern>com/google/common/collect/ImmutableSet.copyOf:.*</exclusionPattern>
-                            <exclusionPattern>com/google/common/collect/Iterables.isEmpty:.*</exclusionPattern>
                         </exclusionPatterns>
                     </configuration>
                     <executions>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -546,6 +546,8 @@
                             <exclusionPattern>com/google/common/collect/ImmutableMap.copyOf:.*</exclusionPattern>
                             <exclusionPattern>com/google/common/collect/ImmutableSet.of:.*</exclusionPattern>
                             <exclusionPattern>com/google/common/collect/ImmutableSet.copyOf:.*</exclusionPattern>
+                            <!-- Keeping Iterables.concat as the alternative Stream.concat(stream1, stream2).collect(Collector.asList()) creates a new List which is not needed -->
+                            <exclusionPattern>com/google/common/collect/Iterables.concat:.*</exclusionPattern>
                         </exclusionPatterns>
                     </configuration>
                     <executions>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -93,7 +93,7 @@
         <dep.jackson.version>2.13.4</dep.jackson.version>
         <dep.jersey.version>2.27</dep.jersey.version>
         <dep.jmh.version>1.35</dep.jmh.version>
-        <dep.jacoco.version>0.8.5</dep.jacoco.version>
+        <dep.jacoco.version>0.8.8</dep.jacoco.version>
         <dep.modernizer.version>2.5.0</dep.modernizer.version>
 
         <platform.jacoco.merged-data-file>${project.build.directory}/merged.exec</platform.jacoco.merged-data-file>
@@ -546,6 +546,7 @@
                             <exclusionPattern>com/google/common/collect/ImmutableMap.copyOf:.*</exclusionPattern>
                             <exclusionPattern>com/google/common/collect/ImmutableSet.of:.*</exclusionPattern>
                             <exclusionPattern>com/google/common/collect/ImmutableSet.copyOf:.*</exclusionPattern>
+                            <exclusionPattern>com/google/common/collect/Iterables.isEmpty:.*</exclusionPattern>
                         </exclusionPatterns>
                     </configuration>
                     <executions>

--- a/reporting-prometheus/src/main/java/com/proofpoint/reporting/MetricsResource.java
+++ b/reporting-prometheus/src/main/java/com/proofpoint/reporting/MetricsResource.java
@@ -17,6 +17,9 @@ package com.proofpoint.reporting;
 
 import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.MoreCollectors;
+import com.google.common.collect.Streams;
 import com.proofpoint.jaxrs.AccessDoesNotRequireAuthentication;
 import com.proofpoint.node.NodeInfo;
 
@@ -78,7 +81,7 @@ public class MetricsResource
                         taggedValue.getValueAndTimestamp().getValue().writeMetric(
                                 writer,
                                 entry.getKey(),
-                                Stream.concat(taggedValue.getTags().entrySet().stream(), instanceTags.entrySet().stream()).collect(Collectors.toList()),
+                                Iterables.concat(taggedValue.getTags().entrySet(), instanceTags.entrySet()),
                                 taggedValue.getValueAndTimestamp().getTimestamp()
                         );
                     }

--- a/reporting-prometheus/src/main/java/com/proofpoint/reporting/MetricsResource.java
+++ b/reporting-prometheus/src/main/java/com/proofpoint/reporting/MetricsResource.java
@@ -17,7 +17,6 @@ package com.proofpoint.reporting;
 
 import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.Iterables;
 import com.proofpoint.jaxrs.AccessDoesNotRequireAuthentication;
 import com.proofpoint.node.NodeInfo;
 
@@ -31,6 +30,8 @@ import java.io.OutputStreamWriter;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -77,7 +78,7 @@ public class MetricsResource
                         taggedValue.getValueAndTimestamp().getValue().writeMetric(
                                 writer,
                                 entry.getKey(),
-                                Iterables.concat(taggedValue.getTags().entrySet(), instanceTags.entrySet()),
+                                Stream.concat(taggedValue.getTags().entrySet().stream(), instanceTags.entrySet().stream()).collect(Collectors.toList()),
                                 taggedValue.getValueAndTimestamp().getTimestamp()
                         );
                     }

--- a/reporting/src/test/java/com/proofpoint/reporting/TestReportBinder.java
+++ b/reporting/src/test/java/com/proofpoint/reporting/TestReportBinder.java
@@ -18,6 +18,7 @@ package com.proofpoint.reporting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
+import com.google.common.collect.MoreCollectors;
 import com.google.inject.Binder;
 import com.google.inject.CreationException;
 import com.google.inject.Guice;
@@ -49,7 +50,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.proofpoint.reporting.BucketIdProvider.BucketId.bucketId;
 import static com.proofpoint.reporting.ReportBinder.reportBinder;
@@ -664,7 +664,7 @@ public class TestReportBinder
     private void assertReportRegistration(Injector injector, boolean applicationPrefix, String namePrefix, Map<String, String> tags, Optional<Set<String>> expectedAttributes)
     {
         ReportedBeanRegistry reportedBeanRegistry = injector.getInstance(ReportedBeanRegistry.class);
-        RegistrationInfo registrationInfo = getOnlyElement(reportedBeanRegistry.getReportedBeans());
+        RegistrationInfo registrationInfo = reportedBeanRegistry.getReportedBeans().stream().collect(MoreCollectors.onlyElement());
         assertEquals(registrationInfo.isApplicationPrefix(), applicationPrefix);
         assertEquals(registrationInfo.getNamePrefix(), namePrefix, "name prefix");
         assertEquals(registrationInfo.getTags(), tags, "tags");

--- a/reporting/src/test/java/com/proofpoint/reporting/TestReportExporter.java
+++ b/reporting/src/test/java/com/proofpoint/reporting/TestReportExporter.java
@@ -16,7 +16,7 @@
 package com.proofpoint.reporting;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
+import com.google.common.collect.MoreCollectors;
 import com.proofpoint.reporting.ReportException.Reason;
 import com.proofpoint.reporting.ReportedBeanRegistry.RegistrationInfo;
 import org.mockito.Mock;
@@ -26,10 +26,11 @@ import org.weakref.jmx.Nested;
 
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
-import static com.google.common.collect.Iterables.getOnlyElement;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -281,16 +282,16 @@ public class TestReportExporter
 
     private void assertExported(boolean applicationPrefix, Map<Object, Object> expectedTags)
     {
-        RegistrationInfo registrationInfo = getOnlyElement(registry.getReportedBeans());
+        RegistrationInfo registrationInfo = registry.getReportedBeans().stream().collect(MoreCollectors.onlyElement());
         assertEquals(registrationInfo.isApplicationPrefix(), applicationPrefix);
         assertEquals(registrationInfo.getNamePrefix(), "TestingObject");
         assertEquals(registrationInfo.getTags(), expectedTags);
         assertEquals(namesOf(registrationInfo.getReportedBean().getAttributes()), namesOf(ReportedBean.forTarget(TESTING_OBJECT, bucketIdProvider).getAttributes()));
     }
 
-    private static Iterable<String> namesOf(Iterable<ReportedBeanAttribute> attributes)
+    private static Collection<String> namesOf(Collection<ReportedBeanAttribute> attributes)
     {
-        return Iterables.transform(attributes, ReportedBeanAttribute::getName);
+        return attributes.stream().map(ReportedBeanAttribute::getName).collect(Collectors.toList());
     }
 
     private static class TestingBucketed


### PR DESCRIPTION
When we have a project on Java 17 and the parent pom is platform, we find that modernizer and jacoco do not run correctly. 

For example
```Execution modernizer of goal org.gaul:modernizer-maven-plugin:2.2.0:modernizer failed: Unsupported class file major version 61```

To fix this I have upgraded jacoco and modernizer.

Because I have updated modernizer I had to fix some bits of the code to compile with new modernizer rules. 