### PR TITLE
Fix snakeYAML

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+Platform 2.85
+
+* Library Upgrades
+
+  - swagger-jaxrs2 to 2.2.9 (was 2.0.0) CVE-2022-1471
+
 Platform 2.84
 
 * Library Upgrades

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -210,15 +210,43 @@
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-jaxrs2</artifactId>
-            <version>2.0.0</version>
+            <version>2.2.9</version>
+            <exclusions>
+                <!-- Can remove when on version 3.29.2-GA of javassist -->
+                <exclusion>
+                    <groupId>org.javassist</groupId>
+                    <artifactId>javassist</artifactId>
+                </exclusion>
+                <!-- Can remove when on version 2.14.2 of jackson-->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jsr310</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <!-- Can remove when on version 2.3.2 of jakarta.xml.bind-api -->
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+                <!-- Can remove when on version 1.2.2 of jakarta.activation-api -->
+                <exclusion>
+                    <groupId>jakarta.activation</groupId>
+                    <artifactId>jakarta.activation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
-        <!-- CVE fix to dependency of Swagger -->
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>1.33</version>
-        </dependency>
 
         <dependency>
             <groupId>org.javassist</groupId>


### PR DESCRIPTION
This upgrades swagger so that we are using snakeYAML 2.0.

To do this I had to put a load of exclusions in so that I'm not breaking enforcer maven plugin rules. 