### PR TITLE
Fix up logging message when discovery fails to find new service instances

### DIFF
--- a/discovery/src/main/java/com/proofpoint/discovery/client/ServiceDescriptorsUpdater.java
+++ b/discovery/src/main/java/com/proofpoint/discovery/client/ServiceDescriptorsUpdater.java
@@ -113,11 +113,13 @@ public final class ServiceDescriptorsUpdater
                     // If no new service descriptors are available, log a warning.
                     // Keep any previous service descriptors to provide some robustness for degraded operation.
                     if (serviceDescriptors.get() == null) {
-                        log.warn("Discovery returned zero available service instances. No previous service " +
-                                "descriptors are available.");
+                        log.warn("Discovery returned zero available service instances for service {}, pool {}. No " +
+                                "previous service descriptors are available.",
+                                newDescriptors.getType(), newDescriptors.getPool());
                     }
                     else {
-                        log.warn("Discovery returned zero available service instances. Keeping previous set of instances.");
+                        log.warn("Discovery returned zero available service instances for service {}, pool {}. Keeping " +
+                                "previous set of instances.", newDescriptors.getType(), newDescriptors.getPool());
                     }
                 }
                 else {


### PR DESCRIPTION
The previous logging message contained no information about *which* service was failing:
```
Discovery returned zero available service instances. No previous service descriptors are available.
Discovery returned zero available service instances. No previous service descriptors are available.
Discovery returned zero available service instances. No previous service descriptors are available.
 ```

This PR just adds service and pool information to the logging messages so we know which service can't be discovered.

