### PR TITLE
Upgrade Jersey to 2.34

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,21 @@
+Platform 2.87
+
+* Jersey upgrade moves dependencies from javax.* to jakarta.* maven coordinates
+
+  javax.validation:validation-api 2.0.1.Final re-introduced to provide compatibility
+  with JEE 8 (for Jetty and Jersey), due to a conflict with Hibernate Validator which
+  also uses jakarta.* coordinates but is based on JEE 9. Use of jakarta.validation
+  packages is still preferred over javax.validation packages
+
+* Library Upgrades
+  - Jersey to 2.34 (was 2.27)
+  - javax.ws.rs-api (2.1) -> jakarta.rs.rs-api (2.1.6)
+  - javax.annotation-api (1.3.1) -> jakarta.annotation-api (1.3.5)
+
 Platform 2.86
 
 * Major version upgrade from Jetty 9 to Jetty 10, which supports the Servlet 4.0
-  specification. This will be the last major version supporting the javax.* packages.
+  specification. This will be the last major Jetty version supporting the javax.* packages.
 
 * Library Upgrades
 

--- a/audit/pom.xml
+++ b/audit/pom.xml
@@ -48,8 +48,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
 
         <dependency>

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -38,8 +38,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
 
         <dependency>

--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -13,6 +13,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>

--- a/discovery/pom.xml
+++ b/discovery/pom.xml
@@ -72,6 +72,10 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>

--- a/event/pom.xml
+++ b/event/pom.xml
@@ -82,6 +82,10 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>

--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -87,6 +87,10 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>
@@ -135,14 +139,14 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
             <optional>true</optional>
         </dependency>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/http-server/pom.xml
+++ b/http-server/pom.xml
@@ -75,6 +75,10 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>
@@ -115,8 +119,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <dependency>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -83,13 +83,17 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <dependency>
@@ -119,7 +123,7 @@
             <exclusions>
                 <exclusion>
                     <groupId>org.glassfish.hk2.external</groupId>
-                    <artifactId>javax.inject</artifactId>
+                    <artifactId>jakarta.inject</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.glassfish.hk2.external</groupId>

--- a/jmx-http/pom.xml
+++ b/jmx-http/pom.xml
@@ -59,8 +59,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <dependency>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -91,7 +91,7 @@
         <dep.logback.version>1.2.11</dep.logback.version>
         <dep.javax-servlet.version>4.0.1</dep.javax-servlet.version>
         <dep.jackson.version>2.13.4</dep.jackson.version>
-        <dep.jersey.version>2.27</dep.jersey.version>
+        <dep.jersey.version>2.34</dep.jersey.version>
         <dep.jmh.version>1.35</dep.jmh.version>
         <dep.jacoco.version>0.8.5</dep.jacoco.version>
         <dep.modernizer.version>2.2.0</dep.modernizer.version>
@@ -821,6 +821,17 @@
                 <artifactId>javax.servlet-api</artifactId>
                 <version>${dep.javax-servlet.version}</version>
             </dependency>
+            <!--
+                Required for JEE 8 compatibility, required by Jersey.
+                Jersey's update to jakarta 2.x packages means these are being superceeded by
+                jakarta.validation-api 3.0.0, which is for JEE 9. Can be removed
+                once we move to Jetty 11 and Jersey 3.x which are also JEE 9
+            -->
+            <dependency>
+                <groupId>javax.validation</groupId>
+                <artifactId>validation-api</artifactId>
+                <version>2.0.1.Final</version>
+            </dependency>
             <dependency>
                 <groupId>jakarta.validation</groupId>
                 <artifactId>jakarta.validation-api</artifactId>
@@ -883,9 +894,9 @@
 
             <!-- jersey -->
             <dependency>
-                <groupId>javax.ws.rs</groupId>
-                <artifactId>javax.ws.rs-api</artifactId>
-                <version>2.1</version>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>2.1.6</version>
             </dependency>
 
             <dependency>
@@ -901,7 +912,7 @@
                 <exclusions>
                     <exclusion>
                         <groupId>org.glassfish.hk2.external</groupId>
-                        <artifactId>javax.inject</artifactId>
+                        <artifactId>jakarta.inject</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>org.glassfish.hk2.external</groupId>
@@ -917,7 +928,7 @@
                 <exclusions>
                     <exclusion>
                         <groupId>org.glassfish.hk2.external</groupId>
-                        <artifactId>javax.inject</artifactId>
+                        <artifactId>jakarta.inject</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -929,7 +940,7 @@
                 <exclusions>
                     <exclusion>
                         <groupId>org.glassfish.hk2.external</groupId>
-                        <artifactId>javax.inject</artifactId>
+                        <artifactId>jakarta.inject</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -953,9 +964,9 @@
             </dependency>
 
             <dependency>
-                <groupId>javax.annotation</groupId>
-                <artifactId>javax.annotation-api</artifactId>
-                <version>1.3.1</version>
+                <groupId>jakarta.annotation</groupId>
+                <artifactId>jakarta.annotation-api</artifactId>
+                <version>1.3.5</version>
             </dependency>
 
             <dependency>

--- a/node/pom.xml
+++ b/node/pom.xml
@@ -33,6 +33,10 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>

--- a/reporting-basemetrics/pom.xml
+++ b/reporting-basemetrics/pom.xml
@@ -27,8 +27,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/sample-server/pom.xml
+++ b/sample-server/pom.xml
@@ -30,6 +30,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>
@@ -62,8 +66,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <dependency>

--- a/skeleton-server/pom.xml
+++ b/skeleton-server/pom.xml
@@ -95,8 +95,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <dependency>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -24,6 +24,10 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>

--- a/units/pom.xml
+++ b/units/pom.xml
@@ -13,6 +13,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>


### PR DESCRIPTION
Jersey upgrade moves dependencies from javax.* to jakarta.* maven coordinates (javax.ws.rs-api -> jakarta.rs.rs-api, and  javax.annotation-api -> jakarta.annotation-api)

javax.validation:validation-api 2.0.1.Final re-introduced to provide compatibility with JEE 8 (for Jetty and Jersey), due to a conflict with Hibernate Validator which also uses jakarta.* coordinates but is based on JEE 9.

