### PR TITLE
Bug Fix: Make SNI Optional

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+Platform 2.88
+
+* Bug Fix: Do not require SNI or Host Checks, as this conflicts with Kubernetes Health Probes
+
 Platform 2.87
 
 * Library Upgrades

--- a/http-client/src/test/java/com/proofpoint/http/client/AbstractHttpClientTest.java
+++ b/http-client/src/test/java/com/proofpoint/http/client/AbstractHttpClientTest.java
@@ -186,11 +186,16 @@ public abstract class AbstractHttpClientTest
 
         List<ConnectionFactory> connectionFactories = new ArrayList<>();
         if (keystore != null) {
-            httpConfiguration.addCustomizer(new SecureRequestCustomizer());
+            SecureRequestCustomizer customizer = new SecureRequestCustomizer();
+            customizer.setSniHostCheck(false);
+            customizer.setSniRequired(false);
+
+            httpConfiguration.addCustomizer(customizer);
 
             sslContextFactory = new SslContextFactory.Server();
             sslContextFactory.setKeyStorePath(keystore);
             sslContextFactory.setKeyStorePassword("changeit");
+            sslContextFactory.setSniRequired(false);
 
             connectionFactories.add(new SslConnectionFactory(sslContextFactory, "alpn"));
             connectionFactories.add(new ALPNServerConnectionFactory("h2", "http/1.1"));

--- a/http-server/src/main/java/com/proofpoint/http/server/HttpServer.java
+++ b/http-server/src/main/java/com/proofpoint/http/server/HttpServer.java
@@ -234,7 +234,10 @@ public class HttpServer
     {
         checkState(!System.getProperty("java.version").startsWith("1.8."), "Java 8 is no longer supported");
 
-        configuration.addCustomizer(new SecureRequestCustomizer());
+        SecureRequestCustomizer customizer = new SecureRequestCustomizer();
+        customizer.setSniHostCheck(false);
+        customizer.setSniRequired(false);
+        configuration.addCustomizer(customizer);
 
         SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
         sslContextFactory.setEndpointIdentificationAlgorithm("HTTPS");
@@ -247,6 +250,7 @@ public class HttpServer
         sslContextFactory.setCipherComparator(Ordering.explicit("", ENABLED_CIPHERS));
         sslContextFactory.setSslSessionTimeout((int) config.getSslSessionTimeout().getValue(SECONDS));
         sslContextFactory.setSslSessionCacheSize(config.getSslSessionCacheSize());
+        sslContextFactory.setSniRequired(false);
 
         List<ConnectionFactory> connectionFactories = new ArrayList<>();
         connectionFactories.add(new SslConnectionFactory(sslContextFactory, "alpn"));


### PR DESCRIPTION
The SNI Host Check is enabled by default which fails Kubernetes Health Check Probes.  Marking SNI as not required will still allow SNI to take place, but a 400 exception will not be thrown if there is a host mis-match.