### PR TITLE
Upgrade base image to 3.10

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+Platform 2.98
+
+* Library Upgrades
+
+  - Base Docker image to c15-java11:3.10 (was 3.2)
+
 Platform 2.97
 
 * HttpClient

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -39,7 +39,7 @@
         <project.rpm.username>${project.artifactId}</project.rpm.username>
         <project.docker.project>dev-docker-local</project.docker.project>
         <project.docker.name>%a</project.docker.name>
-        <project.docker.from>repocache.nonprod.ppops.net/dev-docker-local/c15-java11:3.2</project.docker.from>
+        <project.docker.from>repocache.nonprod.ppops.net/dev-docker-local/c15-java11:3.10</project.docker.from>
         <project.docker.uid>1000</project.docker.uid>
         <project.docker.verbose>false</project.docker.verbose>
 


### PR DESCRIPTION
Latest image `repocache.nonprod.ppops.net/dev-docker-local/c15-java11:3.10` contains package updates for `openjdk-11-jdk-headless` to `11.0.20+8-1~deb11u1` and `openjdk-11-jre-headless` to `11.0.20+8-1~deb11u1`.