### PR TITLE
Update base image to 3.42

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+Platform 3.07
+
+* Library Upgrades
+
+  - Base Docker image to c15-java17:3.42 (was 3.23)
+
 Platform 3.06
 
 * HttpClient

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -39,7 +39,7 @@
         <project.rpm.username>${project.artifactId}</project.rpm.username>
         <project.docker.project>dev-docker-local</project.docker.project>
         <project.docker.name>%a</project.docker.name>
-        <project.docker.from>repocache.nonprod.ppops.net/dev-docker-local/c15-java17:3.23</project.docker.from>
+        <project.docker.from>repocache.nonprod.ppops.net/dev-docker-local/c15-java17:3.42</project.docker.from>
         <project.docker.uid>1000</project.docker.uid>
         <project.docker.verbose>false</project.docker.verbose>
 


### PR DESCRIPTION
Latest image has a patch for `openjdk-17`.  