### PR TITLE
Upgrade base image to 3.44

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+Platform 3.10
+
+* Library Upgrades
+
+  - Base Docker image to c15-java17:3.44 (was 3.42)
+
 Platform 3.09
 
 * HttpServer

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -39,7 +39,7 @@
         <project.rpm.username>${project.artifactId}</project.rpm.username>
         <project.docker.project>dev-docker-local</project.docker.project>
         <project.docker.name>%a</project.docker.name>
-        <project.docker.from>repocache.nonprod.ppops.net/dev-docker-local/c15-java17:3.42</project.docker.from>
+        <project.docker.from>repocache.nonprod.ppops.net/dev-docker-local/c15-java17:3.44</project.docker.from>
         <project.docker.uid>1000</project.docker.uid>
         <project.docker.verbose>false</project.docker.verbose>
 


### PR DESCRIPTION
`c15-java17:3.44` base image contains patches to Debian library `tzdata` (form `2023c-5` to `2023c-5+deb12u1` ) and `base-files` (from `12.4+deb12u2 `to `12.4+deb12u4`)