### PR TITLE
Update base image to 3.45

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+Platform 3.13
+
+* Library Upgrades
+
+  - Base Docker image to c15-java17:3.45 (was 3.44) (CVE-2023-6246 CVE-2023-6779 CVE-2023-6780 CVE-2024-20918 CVE-2024-20919 CVE-2024-20921 CVE-2024-20926 CVE-2024-20932 CVE-2024-20945 CVE-2024-20952)
+
 Platform 3.12
 
 * Library Upgrades

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -39,7 +39,7 @@
         <project.rpm.username>${project.artifactId}</project.rpm.username>
         <project.docker.project>dev-docker-local</project.docker.project>
         <project.docker.name>%a</project.docker.name>
-        <project.docker.from>repocache.nonprod.ppops.net/dev-docker-local/c15-java17:3.44</project.docker.from>
+        <project.docker.from>repocache.nonprod.ppops.net/dev-docker-local/c15-java17:3.45</project.docker.from>
         <project.docker.uid>1000</project.docker.uid>
         <project.docker.verbose>false</project.docker.verbose>
 


### PR DESCRIPTION
The latest base image has patches to `glibc` (https://security-tracker.debian.org/tracker/DSA-5611-1) and `openjdk-17` (https://security-tracker.debian.org/tracker/DSA-5613-1).