### PR TITLE
Allow the admin endpoint to have HSTS header

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,10 @@
+Platform 3.18
+
+* Jaxrs
+
+  - When HSTS headers are enabled (by configuring "jaxrs.hsts.max-age"), we now attach the
+    Strict-Transport-Security header to responses from admin endpoints as well.
+
 Platform 3.17
 
 * Library Upgrades

--- a/jaxrs/src/main/java/com/proofpoint/jaxrs/JaxrsModule.java
+++ b/jaxrs/src/main/java/com/proofpoint/jaxrs/JaxrsModule.java
@@ -106,6 +106,7 @@ public class JaxrsModule
         jaxrsBinder(binder).bind(LivenessResource.class);
         jaxrsBinder(binder).bind(HstsResponseFilter.class);
 
+        jaxrsBinder(binder).bindAdmin(HstsResponseFilter.class);
         jaxrsBinder(binder).bindAdmin(OpenApiResource.class);
         jaxrsBinder(binder).bindAdmin(OpenApiAdminResource.class);
 


### PR DESCRIPTION
This change is to allow the [HSTS headers ](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security#preloading_strict_transport_security) to be present on all admin endpoint.

Our security team was complaining that for a couple of admin endpoints that we added we needed this header. 

It is configured the same as normal by setting
jaxrs.hsts.max-age