### PR TITLE
Update base image to 3.55

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+Platform 3.28
+
+* Library Upgrades
+
+  - Base Docker image to c15-java17:3.55 (was 3.52) (CVE-2024-45490 CVE-2024-45491 CVE-2024-45492)
+
 Platform 3.27
 
 * Library Upgrades

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -39,7 +39,7 @@
         <project.rpm.username>${project.artifactId}</project.rpm.username>
         <project.docker.project>dev-docker-local</project.docker.project>
         <project.docker.name>%a</project.docker.name>
-        <project.docker.from>repocache.nonprod.ppops.net/dev-docker-local/c15-java17:3.52</project.docker.from>
+        <project.docker.from>repocache.nonprod.ppops.net/dev-docker-local/c15-java17:3.55</project.docker.from>
         <project.docker.uid>1000</project.docker.uid>
         <project.docker.verbose>false</project.docker.verbose>
 


### PR DESCRIPTION
Latest base image `c15-java17:3.55` updates `libexpat` to resolve (CVE-2024-45490 CVE-2024-45491 CVE-2024-45492).