### PR TITLE
Update base image to 3.57

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+Platform 3.29
+
+* Library Upgrades
+
+  - Base Docker image to c15-java17:3.57 (was 3.55) (CVE-2024-21208 CVE-2024-21210 CVE-2024-21217 CVE-2024-21235)
+
 Platform 3.28
 
 * Library Upgrades

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -39,7 +39,7 @@
         <project.rpm.username>${project.artifactId}</project.rpm.username>
         <project.docker.project>dev-docker-local</project.docker.project>
         <project.docker.name>%a</project.docker.name>
-        <project.docker.from>repocache.nonprod.ppops.net/dev-docker-local/c15-java17:3.55</project.docker.from>
+        <project.docker.from>repocache.nonprod.ppops.net/dev-docker-local/c15-java17:3.57</project.docker.from>
         <project.docker.uid>1000</project.docker.uid>
         <project.docker.verbose>false</project.docker.verbose>
 


### PR DESCRIPTION
Latest base image updates OpenJDK 17 from `17.0.12+7-2~deb12u1`  to  `17.0.13+11-2~deb12u1`. Fixes the following:
- [CVE-2024-21208](https://security-tracker.debian.org/tracker/CVE-2024-21208)
- [CVE-2024-21210](https://security-tracker.debian.org/tracker/CVE-2024-21210)
- [CVE-2024-21217](https://security-tracker.debian.org/tracker/CVE-2024-21217)
- [CVE-2024-21235](https://security-tracker.debian.org/tracker/CVE-2024-21235)

See [DSA-5794-1](https://security-tracker.debian.org/tracker/DSA-5794-1) for more info.
