### PR TITLE
Update base image to 3.65

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,10 @@ Platform 3.27
 
   We increased the minimum Java version to 17.
 
+* Library Upgrades
+
+  - Base Docker image to c15-java17:3.65 (was 3.57) (CVE-2025-21502)
+
 * Maven plugin upgrades
 
   - maven-shade-plugin to 3.6.0 (was 3.2.2)

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -39,7 +39,7 @@
         <project.rpm.username>${project.artifactId}</project.rpm.username>
         <project.docker.project>dev-docker-local</project.docker.project>
         <project.docker.name>%a</project.docker.name>
-        <project.docker.from>repocache.nonprod.ppops.net/dev-docker-local/c15-java17:3.57</project.docker.from>
+        <project.docker.from>repocache.nonprod.ppops.net/dev-docker-local/c15-java17:3.65</project.docker.from>
         <project.docker.uid>1000</project.docker.uid>
         <project.docker.verbose>false</project.docker.verbose>
 


### PR DESCRIPTION
Latest base image updates OpenJDK 17 from `17.0.13+11-2~deb12u1` to `17.0.14+7-1~deb12u1`. Fixes the following:

[CVE-2025-21502](https://security-tracker.debian.org/tracker/CVE-2025-21502)

See [DSA-5857-1](https://security-tracker.debian.org/tracker/DSA-5857-1) for more info.