### PR TITLE
Use aarch64-compatible jnr-posix

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@ Platform 3.29
   - error_prone_annotations to 2.36.0 (was 2.25.0)
   - error_prone_core to 2.36.0 (was 2.3.4)
   - plexus-compiler-javac-errorprone to 2.15.0 (was 2.8.6)
+  - jnr-posix to 3.0.61 (was 3.0.17)
 
 * Maven plugin upgrades
 

--- a/launcher/pom.xml
+++ b/launcher/pom.xml
@@ -186,7 +186,7 @@
         <dependency>
             <groupId>com.github.jnr</groupId>
             <artifactId>jnr-posix</artifactId>
-            <version>3.0.17</version>
+            <version>3.0.61</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Bump jnr-posix to the final 3.0.x version to make launcher.jar compatible with aarch64 platforms.
